### PR TITLE
Refactor CLI commands and add devcontainer-cli compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,11 +56,32 @@ make install
 - Uses golangci-lint with standard Go linters
 - Standard library preferred over external dependencies where possible
 
+## DevContainer CLI Compatibility
+
+`devgo` aims to provide compatibility with the official devcontainer-cli commands and API. The following commands will be implemented:
+
+### Core Commands (Priority 1)
+- `devgo up` - Create and run dev container (equivalent to `devcontainer up`)
+- `devgo build [path]` - Build a dev container image
+- `devgo exec <cmd> [args...]` - Execute command in running container
+- `devgo stop` - Stop containers
+- `devgo down` - Stop and delete containers
+
+### Extended Commands (Priority 2)
+- `devgo run-user-commands` - Run user commands in container
+- `devgo read-configuration` - Output current workspace configuration
+
+### Global Options
+- `--help` - Show help
+- `--version` - Show version number
+- `--workspace-folder <path>` - Specify project directory (used across commands)
+
 ## Current Implementation Status
 
 - ✅ Basic CLI structure with flag parsing
 - ✅ devcontainer.json discovery logic
 - ✅ GitHub Actions CI/CD pipeline
 - ✅ devcontainer.json parser with comprehensive test coverage
+- 🚧 DevContainer CLI compatibility layer (planned)
 - 🚧 Docker container runner (pending)
 - 🚧 Integration tests (pending)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "fmt"
+
+func runBuildCommand(args []string) error {
+	// TODO: Implement build command
+	fmt.Printf("Running build command with image-name: %s, push: %t\n", *imageName, *push)
+	return fmt.Errorf("build command not implemented")
+}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,0 +1,8 @@
+package cmd
+
+import "fmt"
+
+func runDownCommand(args []string) error {
+	// TODO: Implement down command
+	return fmt.Errorf("down command not implemented")
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,11 @@
+package cmd
+
+import "fmt"
+
+func runExecCommand(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("exec command requires at least one argument")
+	}
+	// TODO: Implement exec command
+	return fmt.Errorf("exec command not implemented")
+}

--- a/cmd/read_configuration.go
+++ b/cmd/read_configuration.go
@@ -1,0 +1,8 @@
+package cmd
+
+import "fmt"
+
+func runReadConfigurationCommand(args []string) error {
+	// TODO: Implement read-configuration command
+	return fmt.Errorf("read-configuration command not implemented")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,10 +11,14 @@ import (
 )
 
 var (
-	configPath    = flag.String("config", "", "Path to devcontainer.json file")
-	forceBuild    = flag.Bool("build", false, "Force rebuild of container")
-	containerName = flag.String("name", "", "Override container name")
-	showHelp      = flag.Bool("help", false, "Show help")
+	workspaceFolder = flag.String("workspace-folder", "", "Path to workspace folder")
+	configPath      = flag.String("config", "", "Path to devcontainer.json file")
+	forceBuild      = flag.Bool("force-build", false, "Force rebuild of container")
+	containerName   = flag.String("name", "", "Override container name")
+	imageName       = flag.String("image-name", "", "Set image name and optional version")
+	push            = flag.Bool("push", false, "Publish the built image")
+	showHelp        = flag.Bool("help", false, "Show help")
+	showVersion     = flag.Bool("version", false, "Show version")
 )
 
 func Execute() error {
@@ -25,25 +29,68 @@ func Execute() error {
 		return nil
 	}
 
+	if *showVersion {
+		showVersionInfo()
+		return nil
+	}
+
 	args := flag.Args()
-	return runDevContainer(args)
+	if len(args) == 0 {
+		return runDevContainer(args)
+	}
+
+	command := args[0]
+	commandArgs := args[1:]
+
+	switch command {
+	case "up":
+		return runUpCommand(commandArgs)
+	case "build":
+		return runBuildCommand(commandArgs)
+	case "exec":
+		return runExecCommand(commandArgs)
+	case "stop":
+		return runStopCommand(commandArgs)
+	case "down":
+		return runDownCommand(commandArgs)
+	case "run-user-commands":
+		return runUserCommandsCommand(commandArgs)
+	case "read-configuration":
+		return runReadConfigurationCommand(commandArgs)
+	default:
+		return runDevContainer(args)
+	}
 }
 
 func showUsage() {
 	fmt.Fprintf(os.Stderr, `devgo - Run commands in a devcontainer based on devcontainer.json
 
 Usage:
-  devgo [flags] [command]
+  devgo [flags] [command] [args...]
+
+Commands:
+  up                       Create and run dev container
+  build [path]            Build a dev container image
+  exec <cmd> [args...]    Execute command in running container
+  stop                    Stop containers
+  down                    Stop and delete containers
+  run-user-commands       Run user commands in container
+  read-configuration      Output current workspace configuration
 
 Flags:
 `)
 	flag.PrintDefaults()
 	fmt.Fprintf(os.Stderr, `
 Examples:
-  devgo                    # Start interactive shell
-  devgo bash               # Run bash command
-  devgo --build            # Force rebuild container
+  devgo up --workspace-folder .
+  devgo build --image-name myapp:latest
+  devgo exec bash
+  devgo stop
 `)
+}
+
+func showVersionInfo() {
+	fmt.Println("devgo version 0.1.0")
 }
 
 func runDevContainer(args []string) error {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -1,0 +1,8 @@
+package cmd
+
+import "fmt"
+
+func runStopCommand(args []string) error {
+	// TODO: Implement stop command
+	return fmt.Errorf("stop command not implemented")
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,0 +1,9 @@
+package cmd
+
+import "fmt"
+
+func runUpCommand(args []string) error {
+	// TODO: Implement up command
+	fmt.Printf("Running up command with workspace-folder: %s\n", *workspaceFolder)
+	return fmt.Errorf("up command not implemented")
+}

--- a/cmd/user_commands.go
+++ b/cmd/user_commands.go
@@ -1,0 +1,8 @@
+package cmd
+
+import "fmt"
+
+func runUserCommandsCommand(args []string) error {
+	// TODO: Implement run-user-commands command
+	return fmt.Errorf("run-user-commands command not implemented")
+}


### PR DESCRIPTION
## Summary
- Refactor CLI commands into separate files for better modularity and maintainability
- Add devcontainer-cli compatibility strategy with command structure
- Implement command routing with switch-based architecture

## Changes
- **New command files**: `up.go`, `build.go`, `exec.go`, `stop.go`, `down.go`, `user_commands.go`, `read_configuration.go`
- **Enhanced root.go**: Switch-based command routing, updated help text, version support
- **New flags**: `--workspace-folder`, `--image-name`, `--push`, `--version` for devcontainer-cli compatibility
- **Updated documentation**: Added devcontainer-cli compatibility strategy to CLAUDE.md

## Test plan
- [x] All commands compile and build successfully
- [x] All existing tests pass
- [x] Linter passes with no issues
- [x] CLI help and version commands work correctly
- [x] All commands return appropriate "not implemented" errors
- [x] Command routing works for all defined commands
- [x] Invalid commands fall back to default behavior

## Architecture
Each command is now in its own file, making it easier to:
- Implement individual command functionality
- Maintain and test commands separately
- Follow single responsibility principle
- Scale the codebase as features are added

🤖 Generated with [Claude Code](https://claude.ai/code)