### PR TITLE
Implement up command with Docker container management

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,9 +1,158 @@
 package cmd
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/garaemon/devgo/pkg/devcontainer"
+)
+
+// DockerRunArgs represents arguments for docker run command
+type DockerRunArgs struct {
+	Name            string
+	Image           string
+	WorkspaceDir    string
+	WorkspaceFolder string
+	Env             map[string]string
+}
+
+// DockerClient interface for Docker operations
+type DockerClient interface {
+	ContainerExists(name string) bool
+	IsContainerRunning(name string) bool
+	StartExistingContainer(name string) error
+	CreateAndStartContainer(args DockerRunArgs) error
+}
+
+// realDockerClient implements DockerClient using actual docker commands
+type realDockerClient struct{}
+
+func newRealDockerClient() DockerClient {
+	return &realDockerClient{}
+}
 
 func runUpCommand(args []string) error {
-	// TODO: Implement up command
-	fmt.Printf("Running up command with workspace-folder: %s\n", *workspaceFolder)
-	return fmt.Errorf("up command not implemented")
+	workspaceDir := determineWorkspaceFolder()
+	
+	devcontainerPath, err := findDevcontainerConfig("")
+	if err != nil {
+		return fmt.Errorf("failed to find devcontainer config: %w", err)
+	}
+
+	devContainer, err := devcontainer.Parse(devcontainerPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse devcontainer.json: %w", err)
+	}
+
+	containerName := determineContainerName(devContainer, workspaceDir)
+	dockerClient := newRealDockerClient()
+	
+	return startContainerWithDocker(devContainer, containerName, workspaceDir, dockerClient)
+}
+
+func determineWorkspaceFolder() string {
+	if *workspaceFolder != "" {
+		return *workspaceFolder
+	}
+	cwd, _ := os.Getwd()
+	return cwd
+}
+
+func determineContainerName(devContainer *devcontainer.DevContainer, workspaceDir string) string {
+	if *containerName != "" {
+		return *containerName
+	}
+	if devContainer.Name != "" {
+		return devContainer.Name
+	}
+	return fmt.Sprintf("devgo-%s", filepath.Base(workspaceDir))
+}
+
+func startContainerWithDocker(devContainer *devcontainer.DevContainer, containerName, workspaceDir string, dockerClient DockerClient) error {
+	if !devContainer.HasImage() {
+		return fmt.Errorf("devcontainer must specify an image")
+	}
+
+	// TODO: Add support for --container-name option similar to devcontainer-cli runArgs
+	// The official devcontainer-cli doesn't have a direct --name option for the up command,
+	// but supports container naming through runArgs in devcontainer.json.
+	// We should consider adding a --container-name option for command-line convenience.
+
+	// Check if container already exists
+	if dockerClient.ContainerExists(containerName) {
+		if dockerClient.IsContainerRunning(containerName) {
+			return fmt.Errorf("container '%s' is already running", containerName)
+		}
+		fmt.Printf("Container '%s' exists but is stopped, starting it\n", containerName)
+		return dockerClient.StartExistingContainer(containerName)
+	}
+
+	fmt.Printf("Creating and starting container '%s' with image '%s'\n", containerName, devContainer.Image)
+
+	dockerArgs := DockerRunArgs{
+		Name:            containerName,
+		Image:           devContainer.Image,
+		WorkspaceDir:    workspaceDir,
+		WorkspaceFolder: devContainer.GetWorkspaceFolder(),
+		Env:             devContainer.ContainerEnv,
+	}
+
+	return dockerClient.CreateAndStartContainer(dockerArgs)
+}
+
+// realDockerClient methods
+func (r *realDockerClient) ContainerExists(containerName string) bool {
+	cmd := exec.Command("docker", "ps", "-a", "--filter", fmt.Sprintf("name=^%s$", containerName), "--format", "{{.Names}}")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == containerName
+}
+
+func (r *realDockerClient) IsContainerRunning(containerName string) bool {
+	cmd := exec.Command("docker", "ps", "--filter", fmt.Sprintf("name=^%s$", containerName), "--format", "{{.Names}}")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == containerName
+}
+
+func (r *realDockerClient) StartExistingContainer(containerName string) error {
+	cmd := exec.Command("docker", "start", containerName)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start existing container: %w\nOutput: %s", err, string(output))
+	}
+	fmt.Printf("Container '%s' started successfully\n", containerName)
+	return nil
+}
+
+func (r *realDockerClient) CreateAndStartContainer(args DockerRunArgs) error {
+	dockerArgs := []string{
+		"run", "-d",
+		"--name", args.Name,
+		"-v", fmt.Sprintf("%s:%s", args.WorkspaceDir, args.WorkspaceFolder),
+	}
+
+	if args.Env != nil {
+		for key, value := range args.Env {
+			dockerArgs = append(dockerArgs, "-e", fmt.Sprintf("%s=%s", key, value))
+		}
+	}
+
+	dockerArgs = append(dockerArgs, args.Image, "sleep", "infinity")
+
+	cmd := exec.Command("docker", dockerArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to start container: %w\nOutput: %s", err, string(output))
+	}
+
+	fmt.Printf("Container '%s' started successfully\n", args.Name)
+	return nil
 }

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/garaemon/devgo/pkg/devcontainer"
+)
+
+// Note: DockerClient interface and DockerRunArgs are defined in up.go
+
+// mockDockerClient implements DockerClient for testing
+type mockDockerClient struct {
+	containers        map[string]bool // name -> isRunning
+	createError       error
+	startError        error
+	existsError       error
+	isRunningError    error
+	createdContainers []DockerRunArgs
+}
+
+func newMockDockerClient() *mockDockerClient {
+	return &mockDockerClient{
+		containers:        make(map[string]bool),
+		createdContainers: make([]DockerRunArgs, 0),
+	}
+}
+
+func (m *mockDockerClient) ContainerExists(name string) bool {
+	if m.existsError != nil {
+		return false
+	}
+	_, exists := m.containers[name]
+	return exists
+}
+
+func (m *mockDockerClient) IsContainerRunning(name string) bool {
+	if m.isRunningError != nil {
+		return false
+	}
+	return m.containers[name]
+}
+
+func (m *mockDockerClient) StartExistingContainer(name string) error {
+	if m.startError != nil {
+		return m.startError
+	}
+	if _, exists := m.containers[name]; !exists {
+		return fmt.Errorf("container %s does not exist", name)
+	}
+	m.containers[name] = true
+	return nil
+}
+
+func (m *mockDockerClient) CreateAndStartContainer(args DockerRunArgs) error {
+	if m.createError != nil {
+		return m.createError
+	}
+	m.containers[args.Name] = true
+	m.createdContainers = append(m.createdContainers, args)
+	return nil
+}
+
+// Helper methods for test setup
+func (m *mockDockerClient) addContainer(name string, isRunning bool) {
+	m.containers[name] = isRunning
+}
+
+func (m *mockDockerClient) setCreateError(err error) {
+	m.createError = err
+}
+
+func (m *mockDockerClient) setStartError(err error) {
+	m.startError = err
+}
+
+func TestRunUpCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		setupMock      func(*mockDockerClient)
+		expectError    bool
+		expectedOutput string
+	}{
+		{
+			name: "container already running",
+			setupMock: func(m *mockDockerClient) {
+				m.addContainer("test-container", true)
+			},
+			expectError:    true,
+			expectedOutput: "container 'test-container' is already running",
+		},
+		{
+			name: "container exists but stopped",
+			setupMock: func(m *mockDockerClient) {
+				m.addContainer("test-container", false)
+			},
+			expectError:    false,
+			expectedOutput: "",
+		},
+		{
+			name: "new container creation",
+			setupMock: func(m *mockDockerClient) {
+				// No existing container
+			},
+			expectError:    false,
+			expectedOutput: "",
+		},
+		{
+			name: "start existing container fails",
+			setupMock: func(m *mockDockerClient) {
+				m.addContainer("test-container", false)
+				m.setStartError(errors.New("start failed"))
+			},
+			expectError:    true,
+			expectedOutput: "start failed",
+		},
+		{
+			name: "create new container fails",
+			setupMock: func(m *mockDockerClient) {
+				m.setCreateError(errors.New("create failed"))
+			},
+			expectError:    true,
+			expectedOutput: "create failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup mock
+			mockDocker := newMockDockerClient()
+			tt.setupMock(mockDocker)
+
+			// Create test devcontainer
+			devContainer := &devcontainer.DevContainer{
+				Name:            "test-container",
+				Image:           "ubuntu:22.04",
+				WorkspaceFolder: "/workspace",
+			}
+
+			// Test the function
+			err := startContainerWithDocker(devContainer, "test-container", "/test/workspace", mockDocker)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				} else if tt.expectedOutput != "" && err.Error() != tt.expectedOutput {
+					t.Errorf("expected error message '%s' but got '%s'", tt.expectedOutput, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestDetermineWorkspaceFolder(t *testing.T) {
+	tests := []struct {
+		name           string
+		workspaceFlag  string
+		expectedResult string
+	}{
+		{
+			name:           "workspace folder flag provided",
+			workspaceFlag:  "/custom/workspace",
+			expectedResult: "/custom/workspace",
+		},
+		{
+			name:           "no workspace folder flag",
+			workspaceFlag:  "",
+			expectedResult: "", // Will be current directory in real implementation
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original value
+			originalWorkspaceFolder := *workspaceFolder
+			defer func() { *workspaceFolder = originalWorkspaceFolder }()
+
+			// Set test value
+			*workspaceFolder = tt.workspaceFlag
+
+			result := determineWorkspaceFolder()
+			if tt.workspaceFlag != "" && result != tt.expectedResult {
+				t.Errorf("expected %s but got %s", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestDetermineContainerName(t *testing.T) {
+	tests := []struct {
+		name             string
+		containerNameFlag string
+		devContainerName  string
+		workspaceDir     string
+		expectedResult   string
+	}{
+		{
+			name:             "container name flag provided",
+			containerNameFlag: "custom-name",
+			devContainerName:  "devcontainer-name",
+			workspaceDir:     "/path/to/workspace",
+			expectedResult:   "custom-name",
+		},
+		{
+			name:             "devcontainer name provided",
+			containerNameFlag: "",
+			devContainerName:  "devcontainer-name",
+			workspaceDir:     "/path/to/workspace",
+			expectedResult:   "devcontainer-name",
+		},
+		{
+			name:             "default name from workspace",
+			containerNameFlag: "",
+			devContainerName:  "",
+			workspaceDir:     "/path/to/workspace",
+			expectedResult:   "devgo-workspace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original value
+			originalContainerName := *containerName
+			defer func() { *containerName = originalContainerName }()
+
+			// Set test value
+			*containerName = tt.containerNameFlag
+
+			devContainer := &devcontainer.DevContainer{
+				Name: tt.devContainerName,
+			}
+
+			result := determineContainerName(devContainer, tt.workspaceDir)
+			if result != tt.expectedResult {
+				t.Errorf("expected %s but got %s", tt.expectedResult, result)
+			}
+		})
+	}
+}
+
+// Test helper functions are now using the actual startContainerWithDocker function


### PR DESCRIPTION
## Summary
- Implement Docker container lifecycle management for the `up` command
- Add testable architecture with dependency injection
- Add comprehensive test coverage with Docker operation mocks

## Changes
- **Docker Interface**: Created `DockerClient` interface for testable Docker operations
- **Container Management**: Handle existing containers (running/stopped) and new container creation
- **Error Handling**: Return appropriate errors for already running containers
- **Test Coverage**: Comprehensive tests for all container scenarios using mocks
- **Container Naming**: Support naming from devcontainer.json, CLI flags, or workspace defaults

## Test Plan
- [x] Unit tests for all up command scenarios with mocked Docker operations
- [x] Integration test with actual Docker container creation
- [x] Linter and existing tests pass
- [x] Manual testing of container lifecycle scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)