### PR TITLE
Implement --verbose flag with unified flag parsing system

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -4,6 +4,6 @@ import "fmt"
 
 func runBuildCommand(args []string) error {
 	// TODO: Implement build command
-	fmt.Printf("Running build command with image-name: %s, push: %t\n", *imageName, *push)
+	fmt.Printf("Running build command with image-name: %s, push: %t\n", imageName, push)
 	return fmt.Errorf("build command not implemented")
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -74,16 +74,16 @@ func runUpCommand(args []string) error {
 }
 
 func determineWorkspaceFolder() string {
-	if *workspaceFolder != "" {
-		return *workspaceFolder
+	if workspaceFolder != "" {
+		return workspaceFolder
 	}
 	cwd, _ := os.Getwd()
 	return cwd
 }
 
 func determineContainerName(devContainer *devcontainer.DevContainer, workspaceDir string) string {
-	if *containerName != "" {
-		return *containerName
+	if containerName != "" {
+		return containerName
 	}
 	if devContainer.Name != "" {
 		return devContainer.Name

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -183,11 +183,11 @@ func TestDetermineWorkspaceFolder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Save original value
-			originalWorkspaceFolder := *workspaceFolder
-			defer func() { *workspaceFolder = originalWorkspaceFolder }()
+			originalWorkspaceFolder := workspaceFolder
+			defer func() { workspaceFolder = originalWorkspaceFolder }()
 
 			// Set test value
-			*workspaceFolder = tt.workspaceFlag
+			workspaceFolder = tt.workspaceFlag
 
 			result := determineWorkspaceFolder()
 			if tt.workspaceFlag != "" && result != tt.expectedResult {
@@ -231,11 +231,11 @@ func TestDetermineContainerName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Save original value
-			originalContainerName := *containerName
-			defer func() { *containerName = originalContainerName }()
+			originalContainerName := containerName
+			defer func() { containerName = originalContainerName }()
 
 			// Set test value
-			*containerName = tt.containerNameFlag
+			containerName = tt.containerNameFlag
 
 			devContainer := &devcontainer.DevContainer{
 				Name: tt.devContainerName,


### PR DESCRIPTION
## Summary
- Add `--verbose` flag that shows directories checked during devcontainer.json discovery
- Refactor flag parsing to support flexible flag positioning (`devgo --verbose up` and `devgo up --verbose`)
- Replace standard Go flag package with custom unified parsing system

## Test plan
- [x] Verify `--verbose` flag shows directory checking output
- [x] Test both flag positions work: `devgo --verbose up` and `devgo up --verbose`
- [x] Confirm all existing functionality remains intact
- [x] Run full test suite to ensure no regressions
- [x] Test help and version commands display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)