### PR TITLE
Add Go 1.23 and 1.24 to GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.21', '1.22', '1.23', '1.24']
         
     steps:
     - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.21
+        go-version: 1.23
         
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v8


### PR DESCRIPTION
## Summary
- Updated test matrix to include Go 1.23 and 1.24 for broader compatibility testing
- Updated linting job to use Go 1.23 instead of 1.21 for more recent tooling

## Test plan
- [x] All existing tests pass locally
- [x] Linting passes with no issues
- [x] CI will run tests against all Go versions including new 1.23 and 1.24

🤖 Generated with [Claude Code](https://claude.ai/code)