### PR TITLE
Add interactive shell command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -88,6 +88,8 @@ func Execute() error {
 		return runBuildCommand(commandArgs)
 	case "exec":
 		return runExecCommand(commandArgs)
+	case "shell":
+		return runShellCommand(commandArgs)
 	case "stop":
 		return runStopCommand(commandArgs)
 	case "down":
@@ -113,6 +115,7 @@ Commands:
   up                       Create and run dev container
   build [path]            Build a dev container image
   exec <cmd> [args...]    Execute command in running container
+  shell                   Start interactive bash shell in container
   stop                    Stop containers
   down                    Stop and delete containers
   list                    List all devgo containers
@@ -145,6 +148,7 @@ Examples:
   devgo up --workspace-folder .
   devgo build --image-name myapp:latest
   devgo exec bash
+  devgo shell
   devgo stop
 `)
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"github.com/garaemon/devgo/pkg/devcontainer"
+	"golang.org/x/term"
+)
+
+func runShellCommand(args []string) error {
+	workspaceDir := determineWorkspaceFolder()
+	
+	devcontainerPath, err := findDevcontainerConfig("")
+	if err != nil {
+		return fmt.Errorf("failed to find devcontainer config: %w", err)
+	}
+
+	devContainer, err := devcontainer.Parse(devcontainerPath)
+	if err != nil {
+		return fmt.Errorf("failed to parse devcontainer.json: %w", err)
+	}
+
+	containerName := determineContainerName(devContainer, workspaceDir)
+	
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("failed to create Docker client: %w", err)
+	}
+	defer func() {
+		if closeErr := cli.Close(); closeErr != nil {
+			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+		}
+	}()
+
+	ctx := context.Background()
+	return executeInteractiveShell(ctx, cli, containerName, devContainer)
+}
+
+func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containerName string, devContainer *devcontainer.DevContainer) error {
+	containerID, err := findRunningContainer(ctx, cli, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to find running container: %w", err)
+	}
+
+	if containerID == "" {
+		return fmt.Errorf("container '%s' is not running. Use 'devgo up' to start it first", containerName)
+	}
+
+	user := devContainer.GetContainerUser()
+	workspaceFolder := devContainer.GetWorkspaceFolder()
+
+	execConfig := container.ExecOptions{
+		User:         user,
+		Tty:          true,
+		AttachStdin:  true,
+		AttachStdout: true,
+		AttachStderr: true,
+		Cmd:          []string{"/bin/bash"},
+		WorkingDir:   workspaceFolder,
+	}
+
+	execCreateResp, err := cli.ContainerExecCreate(ctx, containerID, execConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create exec instance: %w", err)
+	}
+
+	execAttachResp, err := cli.ContainerExecAttach(ctx, execCreateResp.ID, container.ExecAttachOptions{
+		Tty: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to attach to exec instance: %w", err)
+	}
+	defer execAttachResp.Close()
+
+	// Check if stdin is a terminal and set raw mode
+	stdinFd := int(os.Stdin.Fd())
+	var oldState *term.State
+	if term.IsTerminal(stdinFd) {
+		oldState, err = term.MakeRaw(stdinFd)
+		if err != nil {
+			return fmt.Errorf("failed to set terminal to raw mode: %w", err)
+		}
+		defer func() {
+			if restoreErr := term.Restore(stdinFd, oldState); restoreErr != nil {
+				fmt.Printf("Warning: failed to restore terminal: %v\n", restoreErr)
+			}
+		}()
+	}
+
+	// Handle signals to restore terminal state
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		if oldState != nil {
+			_ = term.Restore(stdinFd, oldState)
+		}
+		os.Exit(0)
+	}()
+
+	// Start the exec instance
+	err = cli.ContainerExecStart(ctx, execCreateResp.ID, container.ExecStartOptions{
+		Tty: true,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to start exec instance: %w", err)
+	}
+
+	// Handle TTY I/O like docker exec -it does
+	go func() {
+		defer func() {
+			if closeErr := execAttachResp.CloseWrite(); closeErr != nil && oldState != nil {
+				_ = term.Restore(stdinFd, oldState)
+			}
+		}()
+		_, _ = io.Copy(execAttachResp.Conn, os.Stdin)
+	}()
+
+	// For TTY mode, output is not multiplexed
+	_, err = io.Copy(os.Stdout, execAttachResp.Reader)
+	if err != nil && err != io.EOF {
+		return fmt.Errorf("failed to handle interactive session: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -1,0 +1,284 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/garaemon/devgo/pkg/constants"
+	"github.com/garaemon/devgo/pkg/devcontainer"
+)
+
+func TestExecuteInteractiveShell(t *testing.T) {
+	tests := []struct {
+		name             string
+		containerName    string
+		devContainer     *devcontainer.DevContainer
+		containers       []container.Summary
+		execCreateResp   container.ExecCreateResponse
+		execCreateError  error
+		execAttachError  error
+		expectError      bool
+		expectedErrorMsg string
+	}{
+		{
+			name:          "successful shell execution",
+			containerName: "test-container",
+			devContainer: &devcontainer.DevContainer{
+				ContainerUser:   "root",
+				WorkspaceFolder: "/workspace",
+			},
+			containers: []container.Summary{
+				{
+					ID:    "abc123",
+					Names: []string{"/test-container"},
+					Labels: map[string]string{
+						constants.DevgoManagedLabel: constants.DevgoManagedValue,
+					},
+				},
+			},
+			execCreateResp: container.ExecCreateResponse{
+				ID: "exec123",
+			},
+		},
+		{
+			name:          "container not running",
+			containerName: "missing-container",
+			devContainer: &devcontainer.DevContainer{
+				ContainerUser:   "root",
+				WorkspaceFolder: "/workspace",
+			},
+			containers:       []container.Summary{},
+			expectError:      true,
+			expectedErrorMsg: "is not running",
+		},
+		{
+			name:          "exec create error",
+			containerName: "test-container",
+			devContainer: &devcontainer.DevContainer{
+				ContainerUser:   "root",
+				WorkspaceFolder: "/workspace",
+			},
+			containers: []container.Summary{
+				{
+					ID:    "abc123",
+					Names: []string{"/test-container"},
+					Labels: map[string]string{
+						constants.DevgoManagedLabel: constants.DevgoManagedValue,
+					},
+				},
+			},
+			execCreateError:  fmt.Errorf("failed to create exec"),
+			expectError:      true,
+			expectedErrorMsg: "failed to create exec instance",
+		},
+		{
+			name:          "exec attach error",
+			containerName: "test-container",
+			devContainer: &devcontainer.DevContainer{
+				ContainerUser:   "root",
+				WorkspaceFolder: "/workspace",
+			},
+			containers: []container.Summary{
+				{
+					ID:    "abc123",
+					Names: []string{"/test-container"},
+					Labels: map[string]string{
+						constants.DevgoManagedLabel: constants.DevgoManagedValue,
+					},
+				},
+			},
+			execCreateResp: container.ExecCreateResponse{
+				ID: "exec123",
+			},
+			execAttachError:  fmt.Errorf("failed to attach"),
+			expectError:      true,
+			expectedErrorMsg: "failed to attach to exec instance",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mockResp types.HijackedResponse
+			if tt.name == "successful shell execution" {
+				// For successful execution, provide a proper mock response
+				buf := &bytes.Buffer{}
+				buf.WriteString("root@abc123:/workspace# ")
+				
+				mockResp = types.HijackedResponse{
+					Conn:   &mockConn{Buffer: &bytes.Buffer{}},
+					Reader: bufio.NewReader(buf),
+				}
+			} else {
+				mockResp = createMockHijackedResponse()
+			}
+
+			mockClient := &mockExecClient{
+				containers:         tt.containers,
+				execCreateResponse: tt.execCreateResp,
+				execCreateError:    tt.execCreateError,
+				execAttachResponse: mockResp,
+				execAttachError:    tt.execAttachError,
+			}
+
+			err := executeInteractiveShell(context.Background(), mockClient, tt.containerName, tt.devContainer)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+					return
+				}
+				if tt.expectedErrorMsg != "" && !strings.Contains(err.Error(), tt.expectedErrorMsg) {
+					t.Errorf("error message %q does not contain %q", err.Error(), tt.expectedErrorMsg)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunShellCommand_NoArgs(t *testing.T) {
+	// Shell command should not require arguments (unlike exec)
+	err := runShellCommand([]string{})
+	
+	// Should fail due to missing devcontainer config, not due to argument validation
+	if err != nil && strings.Contains(err.Error(), "requires at least one argument") {
+		t.Errorf("shell command should not require arguments, got: %v", err)
+	}
+	
+	// Should fail with devcontainer config error instead
+	if err == nil {
+		t.Errorf("expected error due to missing devcontainer config, got nil")
+	} else if !strings.Contains(err.Error(), "devcontainer config") {
+		// This is expected - should fail on devcontainer config lookup
+		t.Logf("Expected failure due to missing devcontainer config: %v", err)
+	}
+}
+
+// mockShellExecClient extends mockExecClient to capture exec options
+type mockShellExecClient struct {
+	*mockExecClient
+	capturedExecOptions container.ExecOptions
+}
+
+func (m *mockShellExecClient) ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+	m.capturedExecOptions = config
+	return m.mockExecClient.ContainerExecCreate(ctx, containerID, config)
+}
+
+func TestShellCommandExecOptions(t *testing.T) {
+	// Test that shell command uses correct exec options
+	devContainer := &devcontainer.DevContainer{
+		ContainerUser:   "testuser",
+		WorkspaceFolder: "/test-workspace",
+	}
+
+	containers := []container.Summary{
+		{
+			ID:    "test123",
+			Names: []string{"/test-container"},
+			Labels: map[string]string{
+				constants.DevgoManagedLabel: constants.DevgoManagedValue,
+			},
+		},
+	}
+
+	baseMockClient := &mockExecClient{
+		containers: containers,
+		execCreateResponse: container.ExecCreateResponse{
+			ID: "exec123",
+		},
+		execAttachResponse: createMockHijackedResponse(),
+	}
+
+	mockClient := &mockShellExecClient{
+		mockExecClient: baseMockClient,
+	}
+
+	// This will fail due to terminal handling, but we can still test the exec options
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer)
+
+	// Verify exec options are set correctly for shell command
+	capturedExecOptions := mockClient.capturedExecOptions
+	if capturedExecOptions.User != "testuser" {
+		t.Errorf("expected User to be 'testuser', got %q", capturedExecOptions.User)
+	}
+	if capturedExecOptions.WorkingDir != "/test-workspace" {
+		t.Errorf("expected WorkingDir to be '/test-workspace', got %q", capturedExecOptions.WorkingDir)
+	}
+	if !capturedExecOptions.Tty {
+		t.Errorf("expected Tty to be true for shell command")
+	}
+	if !capturedExecOptions.AttachStdin {
+		t.Errorf("expected AttachStdin to be true for shell command")
+	}
+	if !capturedExecOptions.AttachStdout {
+		t.Errorf("expected AttachStdout to be true for shell command")
+	}
+	if !capturedExecOptions.AttachStderr {
+		t.Errorf("expected AttachStderr to be true for shell command")
+	}
+	
+	// Verify shell command uses /bin/bash
+	expectedCmd := []string{"/bin/bash"}
+	if len(capturedExecOptions.Cmd) != len(expectedCmd) {
+		t.Errorf("expected Cmd to be %v, got %v", expectedCmd, capturedExecOptions.Cmd)
+	} else {
+		for i, cmd := range expectedCmd {
+			if capturedExecOptions.Cmd[i] != cmd {
+				t.Errorf("expected Cmd[%d] to be %q, got %q", i, cmd, capturedExecOptions.Cmd[i])
+			}
+		}
+	}
+}
+
+func TestShellCommandContainerNameLogic(t *testing.T) {
+	// Test that shell command follows the same container naming logic as other commands
+	workspaceDir := "/test/workspace"
+	
+	tests := []struct {
+		name           string
+		devContainer   *devcontainer.DevContainer
+		containerName  string
+		expectedName   string
+	}{
+		{
+			name: "uses devcontainer name",
+			devContainer: &devcontainer.DevContainer{
+				Name: "custom-shell-container",
+			},
+			expectedName: "custom-shell-container",
+		},
+		{
+			name:         "uses workspace directory name",
+			devContainer: &devcontainer.DevContainer{},
+			expectedName: "devgo-workspace",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original global variable
+			originalContainerName := containerName
+			defer func() {
+				containerName = originalContainerName
+			}()
+
+			containerName = tt.containerName
+			result := determineContainerName(tt.devContainer, workspaceDir)
+
+			if result != tt.expectedName {
+				t.Errorf("determineContainerName() = %q, want %q", result, tt.expectedName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `devgo shell` command that starts an interactive bash session in containers
- Implements proper TTY handling with terminal raw mode to prevent command echoing  
- Uses same container discovery and configuration as other commands
- Includes comprehensive unit tests covering execution scenarios and configuration

## Test plan
- [x] Unit tests pass for shell command functionality
- [x] Integration tested manually - shell command works without echoing
- [x] Linter passes with 0 issues
- [x] Help text updated to include shell command
- [x] CLI routing properly handles shell command

🤖 Generated with [Claude Code](https://claude.ai/code)