### PR TITLE
Fix workspace directory resolution for consistent container naming

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -20,12 +20,12 @@ type DownDockerClient interface {
 }
 
 func runDownCommand(args []string) error {
-	workspaceDir := determineWorkspaceFolder()
-	
 	devcontainerPath, err := findDevcontainerConfig("")
 	if err != nil {
 		return fmt.Errorf("failed to find devcontainer config: %w", err)
 	}
+	
+	workspaceDir := determineWorkspaceFolder(devcontainerPath)
 
 	devContainer, err := devcontainer.Parse(devcontainerPath)
 	if err != nil {

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -30,12 +30,12 @@ func runExecCommand(args []string) error {
 		return fmt.Errorf("exec command requires at least one argument")
 	}
 
-	workspaceDir := determineWorkspaceFolder()
-	
 	devcontainerPath, err := findDevcontainerConfig("")
 	if err != nil {
 		return fmt.Errorf("failed to find devcontainer config: %w", err)
 	}
+
+	workspaceDir := determineWorkspaceFolder(devcontainerPath)
 
 	devContainer, err := devcontainer.Parse(devcontainerPath)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	
+	"github.com/garaemon/devgo/pkg/devcontainer"
 	// "github.com/garaemon/devgo/pkg/config"
-	// "github.com/garaemon/devgo/pkg/devcontainer"
 	// "github.com/garaemon/devgo/pkg/docker"
 )
 
@@ -198,4 +199,22 @@ func findDevcontainerConfig(configPath string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no devcontainer.json found in current directory or parent directories")
+}
+
+func determineWorkspaceFolder(devcontainerPath string) string {
+	if workspaceFolder != "" {
+		return workspaceFolder
+	}
+	// Use the directory containing the devcontainer.json as the workspace
+	return filepath.Dir(filepath.Dir(devcontainerPath))
+}
+
+func determineContainerName(devContainer *devcontainer.DevContainer, workspaceDir string) string {
+	if containerName != "" {
+		return containerName
+	}
+	if devContainer.Name != "" {
+		return devContainer.Name
+	}
+	return fmt.Sprintf("devgo-%s", filepath.Base(workspaceDir))
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -15,12 +15,12 @@ import (
 )
 
 func runShellCommand(args []string) error {
-	workspaceDir := determineWorkspaceFolder()
-	
 	devcontainerPath, err := findDevcontainerConfig("")
 	if err != nil {
 		return fmt.Errorf("failed to find devcontainer config: %w", err)
 	}
+
+	workspaceDir := determineWorkspaceFolder(devcontainerPath)
 
 	devContainer, err := devcontainer.Parse(devcontainerPath)
 	if err != nil {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -12,12 +12,12 @@ import (
 )
 
 func runStopCommand(args []string) error {
-	workspaceDir := determineWorkspaceFolder()
-	
 	devcontainerPath, err := findDevcontainerConfig("")
 	if err != nil {
 		return fmt.Errorf("failed to find devcontainer config: %w", err)
 	}
+	
+	workspaceDir := determineWorkspaceFolder(devcontainerPath)
 
 	devContainer, err := devcontainer.Parse(devcontainerPath)
 	if err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
@@ -74,12 +72,12 @@ func newRealDockerClientWithFactory(factory dockerClientFactory) (DockerClient, 
 }
 
 func runUpCommand(args []string) error {
-	workspaceDir := determineWorkspaceFolder()
-	
 	devcontainerPath, err := findDevcontainerConfig("")
 	if err != nil {
 		return fmt.Errorf("failed to find devcontainer config: %w", err)
 	}
+
+	workspaceDir := determineWorkspaceFolder(devcontainerPath)
 
 	devContainer, err := devcontainer.Parse(devcontainerPath)
 	if err != nil {
@@ -101,23 +99,6 @@ func runUpCommand(args []string) error {
 	return startContainerWithDocker(ctx, devContainer, containerName, workspaceDir, dockerClient)
 }
 
-func determineWorkspaceFolder() string {
-	if workspaceFolder != "" {
-		return workspaceFolder
-	}
-	cwd, _ := os.Getwd()
-	return cwd
-}
-
-func determineContainerName(devContainer *devcontainer.DevContainer, workspaceDir string) string {
-	if containerName != "" {
-		return containerName
-	}
-	if devContainer.Name != "" {
-		return devContainer.Name
-	}
-	return fmt.Sprintf("devgo-%s", filepath.Base(workspaceDir))
-}
 
 func startContainerWithDocker(ctx context.Context, devContainer *devcontainer.DevContainer, containerName, workspaceDir string, dockerClient DockerClient) error {
 	if !devContainer.HasImage() {

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -225,9 +225,20 @@ func TestDetermineWorkspaceFolder(t *testing.T) {
 			// Set test value
 			workspaceFolder = tt.workspaceFlag
 
-			result := determineWorkspaceFolder()
-			if tt.workspaceFlag != "" && result != tt.expectedResult {
-				t.Errorf("expected %s but got %s", tt.expectedResult, result)
+			// Create a mock devcontainer path for testing
+			testDevcontainerPath := "/test/workspace/.devcontainer/devcontainer.json"
+			result := determineWorkspaceFolder(testDevcontainerPath)
+			
+			if tt.workspaceFlag != "" {
+				if result != tt.expectedResult {
+					t.Errorf("expected %s but got %s", tt.expectedResult, result)
+				}
+			} else {
+				// When no workspace flag is provided, should use directory containing devcontainer
+				expected := "/test/workspace"
+				if result != expected {
+					t.Errorf("expected %s but got %s", expected, result)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This PR fixes an issue where devgo commands would use different container names when run from different subdirectories within the same workspace.

**Problem:**
- Running `devgo up` from workspace root (e.g., `~/ros1`) creates container `devgo-ros1`  
- Running `devgo shell` from subdirectory (e.g., `~/ros1/src/turtlesim_cleaner`) looks for container `devgo-turtlesim_cleaner`
- This mismatch prevents `devgo shell` from finding the running container

**Solution:**
All devgo commands now consistently use the directory containing `devcontainer.json` as the workspace directory for container naming, regardless of the current working directory.

## Changes

- **`cmd/root.go`**: Added shared `determineWorkspaceFolder()` and `determineContainerName()` functions
- **`cmd/up.go`**: Updated to use new workspace determination logic, removed duplicate functions  
- **`cmd/shell.go`**: Updated to use new workspace determination logic
- **`cmd/exec.go`**: Updated to use new workspace determination logic
- **`cmd/down.go`**: Updated to use new workspace determination logic
- **`cmd/stop.go`**: Updated to use new workspace determination logic
- **`cmd/up_test.go`**: Updated tests to work with new function signature

## Test Plan

- [x] All existing tests pass
- [x] Build succeeds without errors
- [x] Linter passes with no issues
- [x] Manual testing confirms container naming consistency:
  - `devgo up` from workspace root creates expected container
  - `devgo shell` from subdirectory finds the same container
  - Container discovery traverses parent directories correctly

🤖 Generated with [Claude Code](https://claude.ai/code)