### PR TITLE
Add custom prompt to devgo shell command with container name

### DIFF
--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -56,14 +56,21 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 	user := devContainer.GetContainerUser()
 	workspaceFolder := devContainer.GetWorkspaceFolder()
 
+	// Set up custom prompt to indicate dev container environment with container name
+	customPrompt := fmt.Sprintf(`\[\033[01;32m\][devcontainer:%s]\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \$ `, containerName)
+
 	execConfig := container.ExecOptions{
 		User:         user,
 		Tty:          true,
 		AttachStdin:  true,
 		AttachStdout: true,
 		AttachStderr: true,
-		Cmd:          []string{"/bin/bash"},
+		Cmd:          []string{"/bin/bash", "--login"},
 		WorkingDir:   workspaceFolder,
+		Env: []string{
+			fmt.Sprintf("PS1=%s", customPrompt),
+			fmt.Sprintf("PROMPT_COMMAND=PS1='%s'", customPrompt),
+		},
 	}
 
 	execCreateResp, err := cli.ContainerExecCreate(ctx, containerID, execConfig)

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -228,8 +228,8 @@ func TestShellCommandExecOptions(t *testing.T) {
 		t.Errorf("expected AttachStderr to be true for shell command")
 	}
 	
-	// Verify shell command uses /bin/bash
-	expectedCmd := []string{"/bin/bash"}
+	// Verify shell command uses /bin/bash --login with custom prompt in environment
+	expectedCmd := []string{"/bin/bash", "--login"}
 	if len(capturedExecOptions.Cmd) != len(expectedCmd) {
 		t.Errorf("expected Cmd to be %v, got %v", expectedCmd, capturedExecOptions.Cmd)
 	} else {
@@ -237,6 +237,28 @@ func TestShellCommandExecOptions(t *testing.T) {
 			if capturedExecOptions.Cmd[i] != cmd {
 				t.Errorf("expected Cmd[%d] to be %q, got %q", i, cmd, capturedExecOptions.Cmd[i])
 			}
+		}
+	}
+	
+	// Verify custom prompt is set in environment
+	if len(capturedExecOptions.Env) == 0 {
+		t.Errorf("expected environment variables to be set for custom prompt")
+	} else {
+		foundPS1 := false
+		for _, env := range capturedExecOptions.Env {
+			if strings.HasPrefix(env, "PS1=") {
+				foundPS1 = true
+				if !strings.Contains(env, "[devcontainer:") {
+					t.Errorf("expected PS1 environment variable to contain '[devcontainer:', got %q", env)
+				}
+				if !strings.Contains(env, "test-container") {
+					t.Errorf("expected PS1 environment variable to contain container name 'test-container', got %q", env)
+				}
+				break
+			}
+		}
+		if !foundPS1 {
+			t.Errorf("expected PS1 environment variable to be set, got %v", capturedExecOptions.Env)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Add custom prompt to `devgo shell` command showing `[devcontainer:container-name]` indicator
- Display colored prompt similar to official devcontainer CLI to clearly indicate dev container environment
- Include container name in prompt for better identification when working with multiple containers

## Implementation Details  
- Use `bash --login` for proper shell initialization
- Set custom PS1 environment variable with colored prompt format
- Use PROMPT_COMMAND to ensure prompt persists even if overridden by shell initialization files
- Green `[devcontainer:name]` indicator + blue working directory + standard `$` symbol

## Test Plan
- [x] Unit tests verify custom prompt setup and container name inclusion
- [x] Tests pass for shell command execution options
- [x] Linter passes with no issues
- [x] Manual testing confirms custom prompt displays correctly
- [x] Prompt shows format: `[devcontainer:container-name] /workspace $ `

🤖 Generated with [Claude Code](https://claude.ai/code)