### PR TITLE
Add postCreateCommand support to devcontainer configuration

### DIFF
--- a/pkg/devcontainer/devcontainer.go
+++ b/pkg/devcontainer/devcontainer.go
@@ -67,3 +67,37 @@ func (dc *DevContainer) GetContainerUser() string {
 	}
 	return "root"
 }
+
+func (dc *DevContainer) GetPostCreateCommandArgs() []string {
+	if dc.PostCreateCommand == nil {
+		return nil
+	}
+	return parseCommand(dc.PostCreateCommand)
+}
+
+func parseCommand(cmd interface{}) []string {
+	if cmd == nil {
+		return nil
+	}
+
+	switch v := cmd.(type) {
+	case string:
+		// String commands are executed through shell to support shell features
+		// like pipes, redirects, variable expansion, and command chaining (&&, ||)
+		// Example: "npm install && npm run build"
+		return []string{"/bin/sh", "-c", v}
+	case []interface{}:
+		// Array commands are executed directly without shell interpretation
+		// for better security and performance when shell features are not needed
+		// Example: ["npm", "install"]
+		var args []string
+		for _, arg := range v {
+			if str, ok := arg.(string); ok {
+				args = append(args, str)
+			}
+		}
+		return args
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
## Summary
- Add support for postCreateCommand in devcontainer.json configuration
- Support both string and array formats as per devcontainer specification
- Execute postCreateCommand automatically after container creation in up command

## Changes
- Added `GetPostCreateCommandArgs()` method to parse postCreateCommand field
- String commands are executed through shell (`/bin/sh -c`) to support advanced shell features like pipes, redirects, and command chaining
- Array commands are executed directly for better security and performance
- Integrated postCreateCommand execution into the up command workflow
- Added comprehensive unit tests for command parsing logic

## Test plan
- [x] Unit tests for postCreateCommand parsing (string, array, mixed types)
- [x] Integration with existing up command workflow
- [x] All existing tests continue to pass
- [x] Linting passes without issues

🤖 Generated with [Claude Code](https://claude.ai/code)