### PR TITLE
Add personal dotfiles + shell override; fix exec/shell user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  // Project dev container for working on devgo itself.
+  // golangci-lint follows @latest to match .github/workflows; pin both
+  // together if reproducibility across contributors becomes a concern.
+  "name": "devgo",
+  "image": "mcr.microsoft.com/devcontainers/go:1.24",
+  "remoteUser": "vscode",
+  "updateRemoteUserUID": true,
+  "postCreateCommand": "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest && go mod download",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A Go CLI tool that runs Docker containers based on devcontainer.json configurati
 - **waitFor Support** - Control execution order and dependencies
 - **Container Management** - Proper labeling and workspace isolation
 - **Interactive TTY** - Full terminal support for shell sessions
+- **Personal customization** - Per-user dotfiles repository and shell override that stay out of the team's `devcontainer.json` (see [docs/dotfiles.md](docs/dotfiles.md))
 
 ### ❌ Not Yet Implemented
 
@@ -155,7 +156,12 @@ Creates and starts a dev container based on the devcontainer.json configuration.
 devgo up [options]
 
 Options:
-  --workspace-folder PATH    Specify workspace directory (default: current directory)
+  --workspace-folder PATH                    Specify workspace directory (default: current directory)
+  --dotfiles-repository URL                  Override the personal dotfiles repository for this run
+  --dotfiles-target-path PATH                Override the in-container clone target (default "~/dotfiles")
+  --dotfiles-install-command SCRIPT          Override the install script to run after clone
+  --no-dotfiles                              Skip the dotfiles step entirely
+  --force-dotfiles                           Re-clone dotfiles even if the target path already exists
 ```
 
 **Features:**
@@ -164,6 +170,7 @@ Options:
 - Executes lifecycle commands in proper order
 - Handles container reuse if already running
 - Mounts workspace and sets up environment variables
+- Applies the user's personal dotfiles repository (configured in `~/.config/devgo/config.json`) after team lifecycle commands complete; see [docs/dotfiles.md](docs/dotfiles.md) for details
 
 ### `devgo build`
 
@@ -209,11 +216,14 @@ devgo shell [options]
 
 Options:
   --workspace-folder PATH    Specify workspace directory
+  --shell PROGRAM            Program to launch (default /bin/bash). Overrides the
+                             "shell" setting in ~/.config/devgo/config.json.
 ```
 
 **Features:**
 - Full TTY support with proper terminal handling
-- Runs as the configured container user
+- Runs as the dev container's `remoteUser` (falls back to `containerUser`, then `root`), so the user matches the lifecycle commands and personal dotfiles
+- Default shell is `/bin/bash`; configure a personal default in `~/.config/devgo/config.json` (`"shell": "zsh"`) or override per invocation with `--shell`
 - Sets appropriate working directory
 - Handles signal forwarding (Ctrl+C, etc.)
 - Custom detach keys to preserve readline functionality

--- a/cmd/dotfiles_apply_test.go
+++ b/cmd/dotfiles_apply_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/garaemon/devgo/pkg/devcontainer"
+)
+
+// TestApplyDotfiles_NoOpWhenDisabled covers the short-circuit path where
+// --no-dotfiles is set: no Docker client should be created, no container
+// lookup attempted, and the function returns nil.
+func TestApplyDotfiles_NoOpWhenDisabled(t *testing.T) {
+	resetPersonalizationFlags()
+	noDotfiles = true
+	t.Cleanup(resetPersonalizationFlags)
+
+	// Point user config at an empty temp dir to ensure no real config bleeds in.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	dc := &devcontainer.DevContainer{ContainerUser: "vscode"}
+	if err := applyDotfiles(context.Background(), dc, "any-container"); err != nil {
+		t.Errorf("applyDotfiles with --no-dotfiles should be a no-op, got %v", err)
+	}
+}
+
+// TestApplyDotfiles_NoOpWhenNotConfigured covers the short-circuit path
+// when no user config file exists and no CLI flags are set: Resolve
+// returns nil and applyDotfiles must return nil before contacting Docker.
+func TestApplyDotfiles_NoOpWhenNotConfigured(t *testing.T) {
+	resetPersonalizationFlags()
+	t.Cleanup(resetPersonalizationFlags)
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	dc := &devcontainer.DevContainer{ContainerUser: "vscode"}
+	if err := applyDotfiles(context.Background(), dc, "any-container"); err != nil {
+		t.Errorf("applyDotfiles with no config and no flags should be a no-op, got %v", err)
+	}
+}

--- a/cmd/dotfiles_exec.go
+++ b/cmd/dotfiles_exec.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/pkg/stdcopy"
+)
+
+// dotfilesExecExitUnknown signals that the command failed before its real
+// exit code could be observed (e.g. an I/O error). Distinguishes "command
+// ran and returned 0" from "we never got a status".
+const dotfilesExecExitUnknown = -1
+
+// dotfilesDockerClient is the subset of the Docker API used to execute
+// dotfiles commands inside a running container. Defined here (rather than
+// reusing DockerExecClient) so the exit code via ContainerExecInspect can be
+// captured.
+type dotfilesDockerClient interface {
+	ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
+	ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
+	ContainerExecStart(ctx context.Context, execID string, config container.ExecStartOptions) error
+	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
+}
+
+// dotfilesExecutor adapts a Docker client to the dotfiles.Executor interface.
+type dotfilesExecutor struct {
+	cli         dotfilesDockerClient
+	containerID string
+}
+
+// newDotfilesExecutor wraps a Docker client so it satisfies the
+// pkg/dotfiles.Executor interface, scoped to a single container ID.
+func newDotfilesExecutor(cli dotfilesDockerClient, containerID string) *dotfilesExecutor {
+	return &dotfilesExecutor{cli: cli, containerID: containerID}
+}
+
+// Exec runs cmd inside the container as user, capturing stdout/stderr and
+// returning the exit code reported by Docker. On any error before a real
+// exit code is observed it returns dotfilesExecExitUnknown so callers
+// cannot mistake an I/O failure for a successful zero exit.
+//
+// TODO: pass Env explicitly (e.g. HOME from `getent passwd <user>`) for
+// images where switching User via docker exec does not re-export $HOME.
+// pkg/dotfiles.resolveHome currently relies on the shell expanding $HOME.
+func (d *dotfilesExecutor) Exec(ctx context.Context, user string, cmd []string) (string, string, int, error) {
+	execConfig := container.ExecOptions{
+		User:         user,
+		Tty:          false,
+		AttachStdout: true,
+		AttachStderr: true,
+		Cmd:          cmd,
+	}
+
+	create, err := d.cli.ContainerExecCreate(ctx, d.containerID, execConfig)
+	if err != nil {
+		return "", "", dotfilesExecExitUnknown, fmt.Errorf("failed to create exec: %w", err)
+	}
+
+	attach, err := d.cli.ContainerExecAttach(ctx, create.ID, container.ExecAttachOptions{Tty: false})
+	if err != nil {
+		return "", "", dotfilesExecExitUnknown, fmt.Errorf("failed to attach exec: %w", err)
+	}
+	defer attach.Close()
+
+	if err := d.cli.ContainerExecStart(ctx, create.ID, container.ExecStartOptions{}); err != nil {
+		return "", "", dotfilesExecExitUnknown, fmt.Errorf("failed to start exec: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if _, copyErr := stdcopy.StdCopy(&stdout, &stderr, attach.Reader); copyErr != nil && !errors.Is(copyErr, io.EOF) {
+		return stdout.String(), stderr.String(), dotfilesExecExitUnknown, fmt.Errorf("failed to read exec output: %w", copyErr)
+	}
+
+	inspect, err := d.cli.ContainerExecInspect(ctx, create.ID)
+	if err != nil {
+		return stdout.String(), stderr.String(), dotfilesExecExitUnknown, fmt.Errorf("failed to inspect exec: %w", err)
+	}
+
+	return stdout.String(), stderr.String(), inspect.ExitCode, nil
+}

--- a/cmd/dotfiles_exec_test.go
+++ b/cmd/dotfiles_exec_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+)
+
+// mockDotfilesClient mocks the subset of the Docker SDK used by
+// dotfilesExecutor. It captures the User passed to ContainerExecCreate so
+// tests can assert that the executor forwards the caller-supplied user.
+type mockDotfilesClient struct {
+	createErr   error
+	attachErr   error
+	startErr    error
+	inspectErr  error
+	exitCode    int
+	attachResp  types.HijackedResponse
+	createdUser string
+}
+
+func (m *mockDotfilesClient) ContainerExecCreate(_ context.Context, _ string, cfg container.ExecOptions) (container.ExecCreateResponse, error) {
+	m.createdUser = cfg.User
+	if m.createErr != nil {
+		return container.ExecCreateResponse{}, m.createErr
+	}
+	return container.ExecCreateResponse{ID: "exec1"}, nil
+}
+
+func (m *mockDotfilesClient) ContainerExecAttach(_ context.Context, _ string, _ container.ExecAttachOptions) (types.HijackedResponse, error) {
+	if m.attachErr != nil {
+		return types.HijackedResponse{}, m.attachErr
+	}
+	return m.attachResp, nil
+}
+
+func (m *mockDotfilesClient) ContainerExecStart(_ context.Context, _ string, _ container.ExecStartOptions) error {
+	return m.startErr
+}
+
+func (m *mockDotfilesClient) ContainerExecInspect(_ context.Context, _ string) (container.ExecInspect, error) {
+	if m.inspectErr != nil {
+		return container.ExecInspect{}, m.inspectErr
+	}
+	return container.ExecInspect{ExitCode: m.exitCode}, nil
+}
+
+func TestDotfilesExecutor_HappyPath(t *testing.T) {
+	mock := &mockDotfilesClient{
+		attachResp: createMockHijackedResponseValid(),
+		exitCode:   0,
+	}
+	exec := newDotfilesExecutor(mock, "container1")
+	stdout, _, code, err := exec.Exec(context.Background(), "vscode", []string{"true"})
+	if err != nil {
+		t.Fatalf("Exec error = %v, want nil", err)
+	}
+	if code != 0 {
+		t.Errorf("exit code = %d, want 0", code)
+	}
+	if mock.createdUser != "vscode" {
+		t.Errorf("expected User=vscode forwarded, got %q", mock.createdUser)
+	}
+	if !strings.Contains(stdout, "ok") {
+		t.Errorf("expected stdout to include payload, got %q", stdout)
+	}
+}
+
+func TestDotfilesExecutor_CreateError_ReturnsExitUnknown(t *testing.T) {
+	mock := &mockDotfilesClient{createErr: errors.New("boom")}
+	exec := newDotfilesExecutor(mock, "container1")
+	_, _, code, err := exec.Exec(context.Background(), "u", []string{"true"})
+	if err == nil {
+		t.Fatalf("expected error from Exec when ExecCreate fails")
+	}
+	if code != dotfilesExecExitUnknown {
+		t.Errorf("expected exit code = %d (unknown), got %d", dotfilesExecExitUnknown, code)
+	}
+}
+
+func TestDotfilesExecutor_AttachError_ReturnsExitUnknown(t *testing.T) {
+	mock := &mockDotfilesClient{attachErr: errors.New("boom")}
+	exec := newDotfilesExecutor(mock, "container1")
+	_, _, code, err := exec.Exec(context.Background(), "u", []string{"true"})
+	if err == nil {
+		t.Fatalf("expected error from Exec when ExecAttach fails")
+	}
+	if code != dotfilesExecExitUnknown {
+		t.Errorf("expected exit code = %d (unknown), got %d", dotfilesExecExitUnknown, code)
+	}
+}
+
+func TestDotfilesExecutor_StartError_ReturnsExitUnknown(t *testing.T) {
+	mock := &mockDotfilesClient{
+		attachResp: createMockHijackedResponseValid(),
+		startErr:   errors.New("boom"),
+	}
+	exec := newDotfilesExecutor(mock, "container1")
+	_, _, code, err := exec.Exec(context.Background(), "u", []string{"true"})
+	if err == nil {
+		t.Fatalf("expected error from Exec when ExecStart fails")
+	}
+	if code != dotfilesExecExitUnknown {
+		t.Errorf("expected exit code = %d (unknown), got %d", dotfilesExecExitUnknown, code)
+	}
+}
+
+func TestDotfilesExecutor_InspectError_ReturnsExitUnknown(t *testing.T) {
+	mock := &mockDotfilesClient{
+		attachResp: createMockHijackedResponseValid(),
+		inspectErr: errors.New("boom"),
+	}
+	exec := newDotfilesExecutor(mock, "container1")
+	_, _, code, err := exec.Exec(context.Background(), "u", []string{"true"})
+	if err == nil {
+		t.Fatalf("expected error from Exec when ExecInspect fails")
+	}
+	if code != dotfilesExecExitUnknown {
+		t.Errorf("expected exit code = %d (unknown), got %d", dotfilesExecExitUnknown, code)
+	}
+}
+
+func TestDotfilesExecutor_InspectReportsRealExitCode(t *testing.T) {
+	mock := &mockDotfilesClient{
+		attachResp: createMockHijackedResponseValid(),
+		exitCode:   42,
+	}
+	exec := newDotfilesExecutor(mock, "container1")
+	_, _, code, err := exec.Exec(context.Background(), "u", []string{"false"})
+	if err != nil {
+		t.Fatalf("Exec error = %v, want nil (non-zero exit is not an error)", err)
+	}
+	if code != 42 {
+		t.Errorf("expected exit code = 42 from ContainerExecInspect, got %d", code)
+	}
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -89,7 +89,7 @@ func executeCommandInContainer(ctx context.Context, cli DockerExecClient, contai
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	user := devContainer.GetContainerUser()
+	user := devContainer.GetTargetUser()
 	workspaceFolder := devContainer.GetWorkspaceFolder()
 
 	execConfig := container.ExecOptions{

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -40,6 +40,28 @@ func createMockHijackedResponse() types.HijackedResponse {
 	}
 }
 
+// createMockHijackedResponseValid returns a HijackedResponse whose Reader
+// contains a single valid Docker stdcopy frame, so stdcopy.StdCopy returns
+// without error. Tests that exercise the success path of executeCommand-
+// InContainer (and need to assert err == nil) should use this helper.
+func createMockHijackedResponseValid() types.HijackedResponse {
+	buf := &bytes.Buffer{}
+	// Docker stream frame: [stream(1=stdout)][0][0][0][size big-endian 4 bytes][payload]
+	buf.WriteByte(1)
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	buf.WriteByte(0)
+	buf.WriteByte(2)
+	buf.WriteString("ok")
+	return types.HijackedResponse{
+		Conn:   &mockConn{Buffer: &bytes.Buffer{}},
+		Reader: bufio.NewReader(buf),
+	}
+}
+
 // mockExecClient implements a mock Docker client for testing exec functionality
 type mockExecClient struct {
 	containers         []container.Summary
@@ -349,6 +371,86 @@ func TestExecuteCommandInContainer(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+// mockUserCapturingExecClient extends mockExecClient to capture the User
+// field passed to ContainerExecCreate so we can assert which OS user the
+// command runs as.
+type mockUserCapturingExecClient struct {
+	*mockExecClient
+	capturedUser string
+}
+
+func (m *mockUserCapturingExecClient) ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error) {
+	m.capturedUser = config.User
+	return m.mockExecClient.ContainerExecCreate(ctx, containerID, config)
+}
+
+func TestExecuteCommandInContainer_PrefersRemoteUser(t *testing.T) {
+	devContainer := &devcontainer.DevContainer{
+		ContainerUser:   "root",
+		RemoteUser:      "vscode",
+		WorkspaceFolder: "/workspace",
+	}
+	containers := []container.Summary{
+		{
+			ID:    "abc",
+			Names: []string{"/test-container"},
+			Labels: map[string]string{
+				constants.DevgoManagedLabel: constants.DevgoManagedValue,
+			},
+		},
+	}
+	base := &mockExecClient{
+		containers:         containers,
+		execCreateResponse: container.ExecCreateResponse{ID: "exec1"},
+		execAttachResponse: createMockHijackedResponseValid(),
+		inspectResponse: types.ContainerJSON{
+			Config: &container.Config{Env: []string{"PATH=/usr/bin"}},
+		},
+	}
+	mock := &mockUserCapturingExecClient{mockExecClient: base}
+
+	if err := executeCommandInContainer(context.Background(), mock, "test-container", []string{"whoami"}, devContainer); err != nil {
+		t.Fatalf("executeCommandInContainer error = %v", err)
+	}
+
+	if mock.capturedUser != "vscode" {
+		t.Errorf("expected exec to run as remoteUser %q, got %q", "vscode", mock.capturedUser)
+	}
+}
+
+func TestExecuteCommandInContainer_FallsBackToContainerUser(t *testing.T) {
+	devContainer := &devcontainer.DevContainer{
+		ContainerUser:   "node",
+		WorkspaceFolder: "/workspace",
+	}
+	containers := []container.Summary{
+		{
+			ID:    "abc",
+			Names: []string{"/test-container"},
+			Labels: map[string]string{
+				constants.DevgoManagedLabel: constants.DevgoManagedValue,
+			},
+		},
+	}
+	base := &mockExecClient{
+		containers:         containers,
+		execCreateResponse: container.ExecCreateResponse{ID: "exec1"},
+		execAttachResponse: createMockHijackedResponseValid(),
+		inspectResponse: types.ContainerJSON{
+			Config: &container.Config{Env: []string{"PATH=/usr/bin"}},
+		},
+	}
+	mock := &mockUserCapturingExecClient{mockExecClient: base}
+
+	if err := executeCommandInContainer(context.Background(), mock, "test-container", []string{"whoami"}, devContainer); err != nil {
+		t.Fatalf("executeCommandInContainer error = %v", err)
+	}
+
+	if mock.capturedUser != "node" {
+		t.Errorf("expected exec to fall back to containerUser %q, got %q", "node", mock.capturedUser)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,17 +15,23 @@ import (
 )
 
 var (
-	workspaceFolder string
-	configPath      string
-	forceBuild      bool
-	containerName   string
-	imageName       string
-	sessionName     string
-	push            bool
-	pull            bool
-	verbose         bool
-	showHelp        bool
-	showVersion     bool
+	workspaceFolder        string
+	configPath             string
+	forceBuild             bool
+	containerName          string
+	imageName              string
+	sessionName            string
+	push                   bool
+	pull                   bool
+	verbose                bool
+	showHelp               bool
+	showVersion            bool
+	dotfilesRepository     string
+	dotfilesTargetPath     string
+	dotfilesInstallCommand string
+	noDotfiles             bool
+	forceDotfiles          bool
+	shellOverride          string
 )
 
 // parseAllFlags parses all flags from the argument list, returning non-flag arguments
@@ -61,6 +67,22 @@ func parseAllFlags(args []string) ([]string, error) {
 			push = true
 		} else if arg == "--pull" {
 			pull = true
+		} else if arg == "--dotfiles-repository" && i+1 < len(args) {
+			dotfilesRepository = args[i+1]
+			i++
+		} else if arg == "--dotfiles-target-path" && i+1 < len(args) {
+			dotfilesTargetPath = args[i+1]
+			i++
+		} else if arg == "--dotfiles-install-command" && i+1 < len(args) {
+			dotfilesInstallCommand = args[i+1]
+			i++
+		} else if arg == "--no-dotfiles" {
+			noDotfiles = true
+		} else if arg == "--force-dotfiles" {
+			forceDotfiles = true
+		} else if arg == "--shell" && i+1 < len(args) {
+			shellOverride = args[i+1]
+			i++
 		} else if len(arg) > 2 && arg[:2] == "--" {
 			// Check if this is an unknown flag
 			return nil, fmt.Errorf("unknown option: %s", arg)
@@ -124,6 +146,13 @@ func Execute() error {
 	}
 }
 
+// warnf prints a "Warning: ..." message to stderr. Use this for non-fatal
+// problems where the command continues; reserve stdout for the command's
+// real output so warnings don't pollute pipelines.
+func warnf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, "Warning: "+format+"\n", args...)
+}
+
 func showUsage() {
 	fmt.Fprintf(os.Stderr, `devgo - Run commands in a devcontainer based on devcontainer.json
 
@@ -165,6 +194,18 @@ Flags:
         Show version
   --workspace-folder string
         Path to workspace folder
+  --dotfiles-repository string
+        URL of the personal dotfiles repository to clone into the container
+  --dotfiles-target-path string
+        Path inside the container where the dotfiles repo is cloned (default "~/dotfiles")
+  --dotfiles-install-command string
+        Install script to run after cloning (relative to target path)
+  --no-dotfiles
+        Disable dotfiles processing for this invocation
+  --force-dotfiles
+        Re-clone the dotfiles repository even if the target path already exists
+  --shell string
+        Program to launch for 'devgo shell' (overrides shell setting in user config; defaults to /bin/bash)
 
 Examples:
   devgo up --workspace-folder .

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -247,6 +247,104 @@ func TestParseAllFlags_FlagValues(t *testing.T) {
 	}
 }
 
+// resetPersonalizationFlags clears the package-level globals introduced by
+// this PR (dotfiles + shell override). Older flag tests in this file reset
+// only the older globals; this helper covers the per-user / personal flags
+// added together.
+func resetPersonalizationFlags() {
+	dotfilesRepository = ""
+	dotfilesTargetPath = ""
+	dotfilesInstallCommand = ""
+	noDotfiles = false
+	forceDotfiles = false
+	shellOverride = ""
+}
+
+func TestParseAllFlags_ShellFlag(t *testing.T) {
+	resetPersonalizationFlags()
+	if _, err := parseAllFlags([]string{"--shell", "/usr/bin/zsh"}); err != nil {
+		t.Fatalf("parseAllFlags error = %v", err)
+	}
+	if shellOverride != "/usr/bin/zsh" {
+		t.Errorf("shellOverride = %q, want %q", shellOverride, "/usr/bin/zsh")
+	}
+}
+
+func TestParseAllFlags_DotfilesFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		wantRepository string
+		wantTargetPath string
+		wantInstallCmd string
+		wantNoDotfile  bool
+		wantForce      bool
+	}{
+		{
+			name:           "dotfiles-repository",
+			args:           []string{"--dotfiles-repository", "https://example.com/df"},
+			wantRepository: "https://example.com/df",
+		},
+		{
+			name:           "dotfiles-target-path",
+			args:           []string{"--dotfiles-target-path", "/home/u/df"},
+			wantTargetPath: "/home/u/df",
+		},
+		{
+			name:           "dotfiles-install-command",
+			args:           []string{"--dotfiles-install-command", "bootstrap.sh"},
+			wantInstallCmd: "bootstrap.sh",
+		},
+		{
+			name:          "no-dotfiles",
+			args:          []string{"--no-dotfiles"},
+			wantNoDotfile: true,
+		},
+		{
+			name:      "force-dotfiles",
+			args:      []string{"--force-dotfiles"},
+			wantForce: true,
+		},
+		{
+			name: "all dotfiles flags together",
+			args: []string{
+				"--dotfiles-repository", "https://example.com/df",
+				"--dotfiles-target-path", "/df",
+				"--dotfiles-install-command", "setup.sh",
+				"--force-dotfiles",
+			},
+			wantRepository: "https://example.com/df",
+			wantTargetPath: "/df",
+			wantInstallCmd: "setup.sh",
+			wantForce:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetPersonalizationFlags()
+			if _, err := parseAllFlags(tt.args); err != nil {
+				t.Fatalf("parseAllFlags error = %v", err)
+			}
+			if dotfilesRepository != tt.wantRepository {
+				t.Errorf("dotfilesRepository = %q, want %q", dotfilesRepository, tt.wantRepository)
+			}
+			if dotfilesTargetPath != tt.wantTargetPath {
+				t.Errorf("dotfilesTargetPath = %q, want %q", dotfilesTargetPath, tt.wantTargetPath)
+			}
+			if dotfilesInstallCommand != tt.wantInstallCmd {
+				t.Errorf("dotfilesInstallCommand = %q, want %q", dotfilesInstallCommand, tt.wantInstallCmd)
+			}
+			if noDotfiles != tt.wantNoDotfile {
+				t.Errorf("noDotfiles = %v, want %v", noDotfiles, tt.wantNoDotfile)
+			}
+			if forceDotfiles != tt.wantForce {
+				t.Errorf("forceDotfiles = %v, want %v", forceDotfiles, tt.wantForce)
+			}
+		})
+	}
+}
+
 func TestExecute_UnknownOption(t *testing.T) {
 	// Save original os.Args and restore after test
 	oldArgs := os.Args

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -11,9 +11,27 @@ import (
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
+	"github.com/garaemon/devgo/pkg/config"
 	"github.com/garaemon/devgo/pkg/devcontainer"
 	"golang.org/x/term"
 )
+
+// DefaultShell is used when neither --shell nor user config provides a value.
+const DefaultShell = "/bin/bash"
+
+// resolveShellCommand returns the command to run for `devgo shell`. The
+// resolution order is: --shell flag > user config > DefaultShell. The shell
+// is always launched with -i for interactive mode.
+func resolveShellCommand(override string, userConfig *config.UserConfig) []string {
+	shell := DefaultShell
+	if userConfig != nil && userConfig.Shell != "" {
+		shell = userConfig.Shell
+	}
+	if override != "" {
+		shell = override
+	}
+	return []string{shell, "-i"}
+}
 
 func runShellCommand(args []string) error {
 	devcontainerPath, err := findDevcontainerConfig(configPath)
@@ -40,11 +58,18 @@ func runShellCommand(args []string) error {
 		}
 	}()
 
+	userConfig, err := config.LoadUserConfig()
+	if err != nil {
+		warnf("failed to load user config: %v", err)
+		userConfig = &config.UserConfig{}
+	}
+	shellCommand := resolveShellCommand(shellOverride, userConfig)
+
 	ctx := context.Background()
-	return executeInteractiveShell(ctx, cli, containerName, devContainer)
+	return executeInteractiveShell(ctx, cli, containerName, devContainer, shellCommand)
 }
 
-func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containerName string, devContainer *devcontainer.DevContainer) error {
+func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containerName string, devContainer *devcontainer.DevContainer, shellCommand []string) error {
 	containerID, err := findRunningContainer(ctx, cli, containerName)
 	if err != nil {
 		return fmt.Errorf("failed to find running container: %w", err)
@@ -76,7 +101,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	user := devContainer.GetContainerUser()
+	user := devContainer.GetTargetUser()
 	workspaceFolder := devContainer.GetWorkspaceFolder()
 
 	// Get terminal size before creating exec
@@ -98,7 +123,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		AttachStdin:  true,
 		AttachStdout: true,
 		AttachStderr: true,
-		Cmd:          []string{"/bin/bash", "-i"},
+		Cmd:          shellCommand,
 		WorkingDir:   workspaceFolder,
 		Env:          env,
 		ConsoleSize:  consoleSize,

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/garaemon/devgo/pkg/config"
 	"github.com/garaemon/devgo/pkg/constants"
 	"github.com/garaemon/devgo/pkg/devcontainer"
 )
@@ -143,7 +144,7 @@ func TestExecuteInteractiveShell(t *testing.T) {
 				inspectResponse:    tt.inspectResponse,
 			}
 
-			err := executeInteractiveShell(context.Background(), mockClient, tt.containerName, tt.devContainer)
+			err := executeInteractiveShell(context.Background(), mockClient, tt.containerName, tt.devContainer, []string{"/bin/bash", "-i"})
 
 			if tt.expectError {
 				if err == nil {
@@ -160,6 +161,156 @@ func TestExecuteInteractiveShell(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestResolveShellCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string
+		userConfig  *config.UserConfig
+		want     []string
+	}{
+		{
+			name:     "default when nothing set",
+			override: "",
+			userConfig:  nil,
+			want:     []string{"/bin/bash", "-i"},
+		},
+		{
+			name:     "user config wins over default",
+			override: "",
+			userConfig:  &config.UserConfig{Shell: "zsh"},
+			want:     []string{"zsh", "-i"},
+		},
+		{
+			name:     "CLI override wins over user config",
+			override: "/usr/bin/fish",
+			userConfig:  &config.UserConfig{Shell: "zsh"},
+			want:     []string{"/usr/bin/fish", "-i"},
+		},
+		{
+			name:     "CLI override with nil user config",
+			override: "zsh",
+			userConfig:  nil,
+			want:     []string{"zsh", "-i"},
+		},
+		{
+			name:     "empty user config Shell falls back to default",
+			override: "",
+			userConfig:  &config.UserConfig{Shell: ""},
+			want:     []string{"/bin/bash", "-i"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveShellCommand(tt.override, tt.userConfig)
+			if len(got) != len(tt.want) {
+				t.Fatalf("resolveShellCommand() = %v, want %v", got, tt.want)
+			}
+			for i, v := range tt.want {
+				if got[i] != v {
+					t.Errorf("resolveShellCommand()[%d] = %q, want %q", i, got[i], v)
+				}
+			}
+		})
+	}
+}
+
+func TestShellCommand_FallsBackToContainerUser(t *testing.T) {
+	devContainer := &devcontainer.DevContainer{
+		ContainerUser:   "node",
+		WorkspaceFolder: "/workspace",
+	}
+	containers := []container.Summary{
+		{
+			ID:    "test123",
+			Names: []string{"/test-container"},
+			Labels: map[string]string{
+				constants.DevgoManagedLabel: constants.DevgoManagedValue,
+			},
+		},
+	}
+	baseMockClient := &mockExecClient{
+		containers:         containers,
+		execCreateResponse: container.ExecCreateResponse{ID: "exec123"},
+		execAttachResponse: createMockHijackedResponse(),
+		inspectResponse: types.ContainerJSON{
+			Config: &container.Config{Env: []string{"PATH=/usr/bin"}},
+		},
+	}
+	mockClient := &mockShellExecClient{mockExecClient: baseMockClient}
+
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
+
+	if mockClient.capturedExecOptions.User != "node" {
+		t.Errorf("expected shell to fall back to containerUser %q, got %q", "node", mockClient.capturedExecOptions.User)
+	}
+}
+
+func TestShellCommand_PrefersRemoteUser(t *testing.T) {
+	devContainer := &devcontainer.DevContainer{
+		ContainerUser:   "root",
+		RemoteUser:      "vscode",
+		WorkspaceFolder: "/workspace",
+	}
+	containers := []container.Summary{
+		{
+			ID:    "test123",
+			Names: []string{"/test-container"},
+			Labels: map[string]string{
+				constants.DevgoManagedLabel: constants.DevgoManagedValue,
+			},
+		},
+	}
+	baseMockClient := &mockExecClient{
+		containers:         containers,
+		execCreateResponse: container.ExecCreateResponse{ID: "exec123"},
+		execAttachResponse: createMockHijackedResponse(),
+		inspectResponse: types.ContainerJSON{
+			Config: &container.Config{Env: []string{"PATH=/usr/bin"}},
+		},
+	}
+	mockClient := &mockShellExecClient{mockExecClient: baseMockClient}
+
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
+
+	if mockClient.capturedExecOptions.User != "vscode" {
+		t.Errorf("expected shell to run as remoteUser %q, got %q", "vscode", mockClient.capturedExecOptions.User)
+	}
+}
+
+func TestShellCommand_UsesResolvedShell(t *testing.T) {
+	devContainer := &devcontainer.DevContainer{
+		ContainerUser:   "testuser",
+		WorkspaceFolder: "/workspace",
+	}
+	containers := []container.Summary{
+		{
+			ID:    "test123",
+			Names: []string{"/test-container"},
+			Labels: map[string]string{
+				constants.DevgoManagedLabel: constants.DevgoManagedValue,
+			},
+		},
+	}
+	baseMockClient := &mockExecClient{
+		containers:         containers,
+		execCreateResponse: container.ExecCreateResponse{ID: "exec123"},
+		execAttachResponse: createMockHijackedResponse(),
+		inspectResponse: types.ContainerJSON{
+			Config: &container.Config{Env: []string{"PATH=/usr/bin"}},
+		},
+	}
+	mockClient := &mockShellExecClient{mockExecClient: baseMockClient}
+
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"zsh", "-i"})
+
+	got := mockClient.capturedExecOptions.Cmd
+	want := []string{"zsh", "-i"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Errorf("Cmd = %v, want %v", got, want)
 	}
 }
 
@@ -227,7 +378,7 @@ func TestShellCommandExecOptions(t *testing.T) {
 	}
 
 	// This will fail due to terminal handling, but we can still test the exec options
-	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer)
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
 
 	// Verify exec options are set correctly for shell command
 	capturedExecOptions := mockClient.capturedExecOptions
@@ -338,7 +489,7 @@ func TestShellRespectsBashrc(t *testing.T) {
 		mockExecClient: baseMockClient,
 	}
 
-	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer)
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
 
 	capturedExecOptions := mockClient.capturedExecOptions
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -16,8 +16,10 @@ import (
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/garaemon/devgo/pkg/config"
 	"github.com/garaemon/devgo/pkg/constants"
 	"github.com/garaemon/devgo/pkg/devcontainer"
+	"github.com/garaemon/devgo/pkg/dotfiles"
 	"github.com/garaemon/devgo/pkg/sshagent"
 	"github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -647,7 +649,60 @@ func executeLifecycleCommands(ctx context.Context, devContainer *devcontainer.De
 
 	wg.Wait()
 
+	// Personal dotfiles run after every team-defined lifecycle command so
+	// that team setup always completes first. Failures are logged but do
+	// not fail the up command.
+	if err := applyDotfiles(ctx, devContainer, containerName); err != nil {
+		warnf("dotfiles step failed for container %s: %v", containerName, err)
+	}
+
 	return nil
+}
+
+// applyDotfiles loads the user's persistent dotfiles config, merges CLI
+// overrides, and runs the clone/install workflow inside the container. It
+// returns nil when dotfiles are disabled or unconfigured. All other errors
+// (config load, missing container, clone, install) are returned to the
+// caller, which logs them but continues so a broken personal setup never
+// blocks the container from being usable.
+func applyDotfiles(ctx context.Context, devContainer *devcontainer.DevContainer, containerName string) error {
+	userConfig, err := config.LoadUserConfig()
+	if err != nil {
+		return fmt.Errorf("failed to load user config: %w", err)
+	}
+
+	override := dotfiles.Override{
+		Repository:     dotfilesRepository,
+		TargetPath:     dotfilesTargetPath,
+		InstallCommand: dotfilesInstallCommand,
+	}
+	cfg := dotfiles.Resolve(userConfig.Dotfiles, override, noDotfiles)
+	if cfg == nil {
+		return nil
+	}
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("failed to create Docker client for dotfiles: %w", err)
+	}
+	defer func() {
+		if closeErr := cli.Close(); closeErr != nil {
+			warnf("failed to close Docker client: %v", closeErr)
+		}
+	}()
+
+	containerID, err := findRunningContainer(ctx, cli, containerName)
+	if err != nil {
+		return fmt.Errorf("failed to find running container for dotfiles: %w", err)
+	}
+	if containerID == "" {
+		return fmt.Errorf("container %s is not running, cannot apply dotfiles", containerName)
+	}
+
+	executor := newDotfilesExecutor(cli, containerID)
+	user := devContainer.GetTargetUser()
+	fmt.Printf("Checking dotfiles for container %s as user %s\n", containerName, user)
+	return dotfiles.Apply(ctx, executor, user, cfg, forceDotfiles)
 }
 
 func startContainerWithDockerCompose(ctx context.Context, devContainer *devcontainer.DevContainer, containerName, workspaceDir string) error {
@@ -799,13 +854,13 @@ func createComposeOverrideFile(service string, env map[string]string) (string, e
 
 	var content strings.Builder
 	content.WriteString("services:\n")
-	content.WriteString(fmt.Sprintf("  %s:\n", service))
+	fmt.Fprintf(&content, "  %s:\n", service)
 	content.WriteString("    environment:\n")
 
 	for k, v := range env {
 		escapedVal := strings.ReplaceAll(v, "\\", "\\\\")
 		escapedVal = strings.ReplaceAll(escapedVal, "\"", "\\\"")
-		content.WriteString(fmt.Sprintf("      %s: \"%s\"\n", k, escapedVal))
+		fmt.Fprintf(&content, "      %s: \"%s\"\n", k, escapedVal)
 	}
 
 	if _, err := file.WriteString(content.String()); err != nil {

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -1,0 +1,175 @@
+# Personal dotfiles support in devgo
+
+`devgo` supports cloning a personal dotfiles repository into the dev container
+and running an install script after the container is ready. This lets each
+user keep their own shell setup, aliases, prompt, and editor config separate
+from the team's `devcontainer.json` (which is shared via git).
+
+## Background
+
+`devcontainer.json` is committed to the repository and shared with the whole
+team, so it is the wrong place to put personal customizations such as zsh
+configuration, individual aliases, or personal CLI tools. VS Code, GitHub
+Codespaces, and DevPod all solve this problem with a *dotfiles repository*
+mechanism that is **not part of the official [devcontainer
+spec](https://containers.dev/implementors/json_reference/)** but has become a
+de-facto convention.
+
+`devgo` follows the same convention and intentionally uses the same three
+configuration keys VS Code uses (`repository`, `targetPath`,
+`installCommand`), so users coming from VS Code do not need to learn anything
+new.
+
+## Configuration
+
+### Persistent configuration file
+
+Personal settings live in `~/.config/devgo/config.json`. The file is loaded
+automatically when `devgo up` runs.
+
+```json
+{
+  "dotfiles": {
+    "repository": "https://github.com/your-user/dotfiles",
+    "targetPath": "~/dotfiles",
+    "installCommand": "install.sh"
+  }
+}
+```
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `repository` | yes | — | Git URL of the dotfiles repository. Any URL `git clone` accepts (https, ssh, git protocol). |
+| `targetPath` | no | `~/dotfiles` | Directory inside the container where the repository is cloned. A leading `~` or `~/` is expanded to the target user's `$HOME` (resolved inside the container). The target should not be the home directory itself, since `git clone` refuses to write into a non-empty directory. |
+| `installCommand` | no | (auto) | Path of the install script to execute after cloning, relative to `targetPath`. When empty, devgo searches for a known script (see below). |
+
+### Auto-detected install script
+
+When `installCommand` is empty, devgo looks for the following scripts in the
+cloned repository in order, and runs the first one it finds:
+
+```
+install.sh
+install
+bootstrap.sh
+bootstrap
+setup.sh
+setup
+```
+
+If none are found, the dotfiles are left in `targetPath` without further
+processing (clone-only mode).
+
+### Command-line overrides
+
+Every key can be overridden on the command line for a single `devgo up`
+invocation:
+
+```
+--dotfiles-repository <url>          Override repository URL
+--dotfiles-target-path <path>        Override target path
+--dotfiles-install-command <script>  Override install script
+--no-dotfiles                        Disable dotfiles entirely (e.g. on CI)
+--force-dotfiles                     Re-clone even if targetPath already exists
+```
+
+The CLI flags take precedence over `~/.config/devgo/config.json`.
+
+## Execution model
+
+* Dotfiles are processed **after all lifecycle commands have completed**
+  (`onCreate`, `updateContent`, `postCreate`, `postStart`, `postAttach`). Team
+  setup always wins, then the personal layer goes on top. This means `devgo
+  up` waits for the full lifecycle even when `waitFor` is set to an earlier
+  step; the dotfiles step runs synchronously after `wg.Wait()` returns. If
+  you want `up` to return faster, run with `--no-dotfiles` and apply your
+  dotfiles manually later.
+* `git clone` runs **inside the container**, as the target user (`remoteUser`
+  if set, otherwise `containerUser`, otherwise `root`). The same user is used
+  by `devgo exec` and `devgo shell`, so the cloned dotfiles end up under the
+  same `$HOME` you land in interactively. SSH agent forwarding configured by
+  devgo is reused, so private repositories work transparently when the host
+  has the right keys loaded.
+* If `targetPath` already exists, devgo **skips both clone and install** to
+  avoid trampling over user changes. Use `--force-dotfiles` to override.
+* The install script runs as a single `sh -c "cd <targetPath> && <script>"`.
+  Both the `cd` and the script execute inside the same shell, so any
+  environment variables exported by the script affect only that shell.
+* The install script must be **executable** (`chmod +x install.sh`) and have
+  a shebang the container can resolve. Non-zero exit codes 126 (not
+  executable) and 127 (interpreter missing) trigger an explicit hint in the
+  resulting error message.
+* Failures during dotfiles processing are **logged but do not fail
+  `devgo up`**. A broken personal setup must never block access to the
+  container.
+
+## Examples
+
+### Minimal: configure once, all projects use it
+
+```
+mkdir -p ~/.config/devgo
+cat > ~/.config/devgo/config.json <<'EOF'
+{
+  "dotfiles": {
+    "repository": "https://github.com/your-user/dotfiles"
+  }
+}
+EOF
+
+cd some-project-with-devcontainer
+devgo up
+```
+
+### One-off override for a single container
+
+```
+devgo up --dotfiles-repository https://github.com/other-user/dotfiles
+```
+
+### Disable dotfiles (CI environments)
+
+```
+devgo up --no-dotfiles
+```
+
+### Re-apply dotfiles after editing the upstream repository
+
+```
+devgo up --force-dotfiles
+```
+
+## Other personal settings in the same config file
+
+The user config file (`~/.config/devgo/config.json`) is shared by every
+personal customization devgo supports. In addition to `dotfiles`, the
+following top-level keys are recognized:
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `shell` | `/bin/bash` | Program launched by `devgo shell`. Useful for users who prefer `zsh`, `fish`, etc. Always invoked with `-i`. |
+
+Example with both dotfiles and a custom shell:
+
+```json
+{
+  "shell": "zsh",
+  "dotfiles": {
+    "repository": "https://github.com/your-user/dotfiles"
+  }
+}
+```
+
+The `--shell` CLI flag overrides the value for a single `devgo shell`
+invocation.
+
+## What devgo intentionally does *not* do
+
+* **Overlay the team's `devcontainer.json` itself.** Adding personal mounts,
+  environment variables, or lifecycle commands is out of scope for the
+  dotfiles feature. A separate `devcontainer.local.json` overlay mechanism
+  may be added in a future release.
+* **Manage the dotfiles repository for you.** devgo only clones and runs the
+  install script. Anything else (symlinking, package installation,
+  shell-switch logic) belongs in the install script inside the dotfiles
+  repository.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,13 +1,38 @@
 package config
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 )
 
 type Config struct {
 	DockerHost      string
 	ContainerPrefix string
 	WorkspaceMount  string
+}
+
+// DotfilesConfig holds the persistent dotfiles preferences loaded from
+// ~/.config/devgo/config.json. CLI flags may override these values at run
+// time; that merging is performed by pkg/dotfiles, not here.
+type DotfilesConfig struct {
+	Repository     string `json:"repository,omitempty"`
+	TargetPath     string `json:"targetPath,omitempty"`
+	InstallCommand string `json:"installCommand,omitempty"`
+}
+
+// UserConfig represents the contents of ~/.config/devgo/config.json. It is
+// kept separate from Config (which is environment-derived) so each loader can
+// evolve independently.
+type UserConfig struct {
+	// Dotfiles is the personal dotfiles repository configuration. Nil
+	// means dotfiles are not configured for this user.
+	Dotfiles *DotfilesConfig `json:"dotfiles,omitempty"`
+	// Shell overrides the program devgo invokes for `devgo shell`. When
+	// empty, devgo falls back to /bin/bash. Always launched with -i.
+	Shell string `json:"shell,omitempty"`
 }
 
 func Load() (*Config, error) {
@@ -18,6 +43,47 @@ func Load() (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+// UserConfigPath returns the path to the per-user devgo config file. It
+// honors XDG_CONFIG_HOME when set, and falls back to ~/.config/devgo/config.json.
+func UserConfigPath() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "devgo", "config.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine user home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "devgo", "config.json"), nil
+}
+
+// LoadUserConfig loads the user-global config from the default location. A
+// missing file is not an error and yields an empty UserConfig.
+func LoadUserConfig() (*UserConfig, error) {
+	path, err := UserConfigPath()
+	if err != nil {
+		return nil, err
+	}
+	return LoadUserConfigFile(path)
+}
+
+// LoadUserConfigFile reads a UserConfig from the given path. A missing file
+// is treated as an empty configuration (no error).
+func LoadUserConfigFile(path string) (*UserConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &UserConfig{}, nil
+		}
+		return nil, fmt.Errorf("failed to read user config %s: %w", path, err)
+	}
+
+	var cfg UserConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to parse user config %s: %w", path, err)
+	}
+	return &cfg, nil
 }
 
 func getEnv(key, defaultValue string) string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -95,5 +96,112 @@ func TestGetEnv_WithEmptyValue(t *testing.T) {
 
 	if result != defaultValue {
 		t.Errorf("getEnv() = %v, want %v", result, defaultValue)
+	}
+}
+
+func TestLoadUserConfigFile_Missing(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+
+	cfg, err := LoadUserConfigFile(path)
+	if err != nil {
+		t.Fatalf("LoadUserConfigFile() unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatalf("LoadUserConfigFile() returned nil, want empty UserConfig")
+	}
+	if cfg.Dotfiles != nil {
+		t.Errorf("expected Dotfiles to be nil for missing file, got %+v", cfg.Dotfiles)
+	}
+}
+
+func TestLoadUserConfigFile_ShellField(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+	if err := os.WriteFile(path, []byte(`{"shell": "zsh"}`), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	cfg, err := LoadUserConfigFile(path)
+	if err != nil {
+		t.Fatalf("LoadUserConfigFile() error = %v", err)
+	}
+	if cfg.Shell != "zsh" {
+		t.Errorf("Shell = %q, want %q", cfg.Shell, "zsh")
+	}
+}
+
+func TestLoadUserConfigFile_FullDotfiles(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+	contents := `{
+  "dotfiles": {
+    "repository": "https://github.com/example/dotfiles",
+    "targetPath": "/home/user/dotfiles",
+    "installCommand": "bootstrap.sh"
+  }
+}`
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	cfg, err := LoadUserConfigFile(path)
+	if err != nil {
+		t.Fatalf("LoadUserConfigFile() error = %v", err)
+	}
+	if cfg.Dotfiles == nil {
+		t.Fatalf("Dotfiles is nil, want populated")
+	}
+	if cfg.Dotfiles.Repository != "https://github.com/example/dotfiles" {
+		t.Errorf("Repository = %q, want %q", cfg.Dotfiles.Repository, "https://github.com/example/dotfiles")
+	}
+	if cfg.Dotfiles.TargetPath != "/home/user/dotfiles" {
+		t.Errorf("TargetPath = %q, want %q", cfg.Dotfiles.TargetPath, "/home/user/dotfiles")
+	}
+	if cfg.Dotfiles.InstallCommand != "bootstrap.sh" {
+		t.Errorf("InstallCommand = %q, want %q", cfg.Dotfiles.InstallCommand, "bootstrap.sh")
+	}
+}
+
+func TestLoadUserConfigFile_MalformedJSON(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "config.json")
+	if err := os.WriteFile(path, []byte("{ this is not json"), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	if _, err := LoadUserConfigFile(path); err == nil {
+		t.Fatalf("expected error for malformed JSON, got nil")
+	}
+}
+
+func TestUserConfigPath_FromXDGEnv(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	got, err := UserConfigPath()
+	if err != nil {
+		t.Fatalf("UserConfigPath() error = %v", err)
+	}
+	want := filepath.Join(tmp, "devgo", "config.json")
+	if got != want {
+		t.Errorf("UserConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestUserConfigPath_DefaultsToHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	// Pin HOME so the test does not depend on the runner's environment.
+	t.Setenv("HOME", tmp)
+
+	got, err := UserConfigPath()
+	if err != nil {
+		t.Fatalf("UserConfigPath() error = %v", err)
+	}
+
+	want := filepath.Join(tmp, ".config", "devgo", "config.json")
+	if got != want {
+		t.Errorf("UserConfigPath() = %q, want %q", got, want)
 	}
 }

--- a/pkg/dotfiles/dotfiles.go
+++ b/pkg/dotfiles/dotfiles.go
@@ -1,0 +1,297 @@
+// Package dotfiles applies a personal dotfiles repository inside a running
+// dev container. The configuration follows VS Code's de-facto convention:
+// repository, targetPath, installCommand. See docs/dotfiles.md for details.
+package dotfiles
+
+import (
+	"context"
+	"fmt"
+	"path"
+	"regexp"
+	"strings"
+
+	"github.com/garaemon/devgo/pkg/config"
+)
+
+// credentialURLPattern matches the userinfo portion of a URL of the form
+// `scheme://user[:password]@host...`. Used by SanitizeRepoURL to strip
+// embedded credentials before they reach logs or error messages.
+var credentialURLPattern = regexp.MustCompile(`^([a-zA-Z][a-zA-Z0-9+\-.]*://)[^/@\s]+@`)
+
+// DefaultTargetPath is used when neither the persistent config nor a CLI
+// override specifies targetPath. The repo is cloned into a subdirectory of
+// $HOME (rather than $HOME itself) because git clone refuses non-empty
+// targets, and the user's home is rarely empty.
+const DefaultTargetPath = "~/dotfiles"
+
+// DefaultInstallScripts is the ordered list of script names devgo searches
+// for when installCommand is unset. Mirrors the convention used by VS Code's
+// dev containers extension.
+var DefaultInstallScripts = []string{
+	"install.sh",
+	"install",
+	"bootstrap.sh",
+	"bootstrap",
+	"setup.sh",
+	"setup",
+}
+
+// Config is the resolved per-invocation dotfiles configuration.
+type Config struct {
+	Repository     string
+	TargetPath     string
+	InstallCommand string
+}
+
+// Override holds CLI-supplied values. Empty fields fall back to the user
+// config file. Strings are used (not pointers) since dotfiles values are all
+// non-empty when set.
+type Override struct {
+	Repository     string
+	TargetPath     string
+	InstallCommand string
+}
+
+// Executor runs a command inside the target container as the given user. The
+// implementation is provided by the caller (typically the cmd package backed
+// by the Docker exec API). Tests inject a fake.
+type Executor interface {
+	Exec(ctx context.Context, user string, cmd []string) (stdout string, stderr string, exitCode int, err error)
+}
+
+// Resolve combines the persistent user config with CLI overrides. It returns
+// nil when dotfiles processing should be skipped (disabled flag, or no
+// repository configured anywhere).
+func Resolve(fileCfg *config.DotfilesConfig, override Override, disabled bool) *Config {
+	if disabled {
+		return nil
+	}
+
+	cfg := &Config{}
+	if fileCfg != nil {
+		cfg.Repository = fileCfg.Repository
+		cfg.TargetPath = fileCfg.TargetPath
+		cfg.InstallCommand = fileCfg.InstallCommand
+	}
+	if override.Repository != "" {
+		cfg.Repository = override.Repository
+	}
+	if override.TargetPath != "" {
+		cfg.TargetPath = override.TargetPath
+	}
+	if override.InstallCommand != "" {
+		cfg.InstallCommand = override.InstallCommand
+	}
+
+	if cfg.Repository == "" {
+		return nil
+	}
+	if cfg.TargetPath == "" {
+		cfg.TargetPath = DefaultTargetPath
+	}
+	return cfg
+}
+
+// Apply clones the dotfiles repository inside the container and runs the
+// install script. It is fail-soft from the caller's perspective: errors are
+// returned but the caller (cmd/up.go) is expected to log and continue.
+//
+// Behavior:
+//   - If targetPath already exists and force is false, the function logs
+//     "already present" and returns nil.
+//   - If force is true and targetPath exists, the existing path is removed
+//     before cloning.
+//   - If force is true and targetPath does not exist, force has no effect
+//     and the clone proceeds as it would otherwise.
+//   - When InstallCommand is empty, devgo probes DefaultInstallScripts in
+//     order and runs the first match. If none match, the clone is left in
+//     place (clone-only mode).
+func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force bool) error {
+	if cfg == nil {
+		return nil
+	}
+	if cfg.Repository == "" {
+		return fmt.Errorf("dotfiles repository is empty")
+	}
+
+	target, err := resolveHome(ctx, exec, user, cfg.TargetPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve target path %s: %w", cfg.TargetPath, err)
+	}
+
+	exists, err := pathExists(ctx, exec, user, target)
+	if err != nil {
+		return fmt.Errorf("failed to check target path %s: %w", target, err)
+	}
+
+	if exists {
+		if !force {
+			fmt.Printf("dotfiles target %s already exists, skipping (use --force-dotfiles to overwrite)\n", target)
+			return nil
+		}
+		if err := removePath(ctx, exec, user, target); err != nil {
+			return fmt.Errorf("failed to remove existing target %s: %w", target, err)
+		}
+	}
+
+	fmt.Printf("Applying dotfiles from %s into %s\n", SanitizeRepoURL(cfg.Repository), target)
+	if err := cloneRepo(ctx, exec, user, cfg.Repository, target); err != nil {
+		return fmt.Errorf("failed to clone dotfiles: %w", err)
+	}
+
+	script, err := resolveInstallScript(ctx, exec, user, target, cfg.InstallCommand)
+	if err != nil {
+		return fmt.Errorf("failed to resolve install script: %w", err)
+	}
+	if script == "" {
+		fmt.Println("dotfiles cloned; no install script found, skipping install step")
+		return nil
+	}
+
+	if err := runInstallScript(ctx, exec, user, target, script); err != nil {
+		return fmt.Errorf("install script %s failed: %w", script, err)
+	}
+
+	fmt.Printf("dotfiles installed from %s\n", SanitizeRepoURL(cfg.Repository))
+	return nil
+}
+
+// resolveHome replaces a leading "~" or "~/" in p with the target user's
+// $HOME, queried inside the container. Paths that do not start with "~" are
+// returned unchanged. The "~user" form (other-user expansion) is rejected
+// explicitly so it does not silently fall through and become a literal
+// directory name.
+func resolveHome(ctx context.Context, exec Executor, user, p string) (string, error) {
+	if p != "~" && !strings.HasPrefix(p, "~/") {
+		if strings.HasPrefix(p, "~") {
+			return "", fmt.Errorf("targetPath %q uses unsupported ~user form; only ~ and ~/ are expanded", p)
+		}
+		return p, nil
+	}
+	stdout, stderr, exitCode, err := exec.Exec(ctx, user, []string{"sh", "-c", `printf %s "$HOME"`})
+	if err != nil {
+		return "", err
+	}
+	if exitCode != 0 {
+		return "", fmt.Errorf("failed to read $HOME: exit %d: %s", exitCode, stderr)
+	}
+	home := strings.TrimSpace(stdout)
+	if home == "" {
+		return "", fmt.Errorf("$HOME is empty for user %s", user)
+	}
+	if p == "~" {
+		return home, nil
+	}
+	return home + p[1:], nil
+}
+
+func pathExists(ctx context.Context, exec Executor, user, p string) (bool, error) {
+	cmd := []string{"sh", "-c", fmt.Sprintf("[ -e %s ]", shellQuote(p))}
+	_, _, exitCode, err := exec.Exec(ctx, user, cmd)
+	if err != nil {
+		return false, err
+	}
+	return exitCode == 0, nil
+}
+
+func removePath(ctx context.Context, exec Executor, user, p string) error {
+	cmd := []string{"sh", "-c", fmt.Sprintf("rm -rf %s", shellQuote(p))}
+	_, stderr, exitCode, err := exec.Exec(ctx, user, cmd)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("rm exited with %d: %s", exitCode, stderr)
+	}
+	return nil
+}
+
+func cloneRepo(ctx context.Context, exec Executor, user, repo, target string) error {
+	cmd := []string{"sh", "-c", fmt.Sprintf("git clone %s %s", shellQuote(repo), shellQuote(target))}
+	stdout, stderr, exitCode, err := exec.Exec(ctx, user, cmd)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		// Mask credentials: git's stderr can echo back the URL on auth failure.
+		safe := SanitizeRepoURL(repo)
+		cleanStdout := strings.ReplaceAll(stdout, repo, safe)
+		cleanStderr := strings.ReplaceAll(stderr, repo, safe)
+		return fmt.Errorf("git clone %s exited with %d: stdout=%q stderr=%q", safe, exitCode, cleanStdout, cleanStderr)
+	}
+	return nil
+}
+
+func resolveInstallScript(ctx context.Context, exec Executor, user, targetPath, explicit string) (string, error) {
+	if explicit != "" {
+		// When the user pinned a script name, surface a clear "missing"
+		// error rather than letting the eventual `sh -c './script'` fail
+		// with exit 127 mixed into other install error paths.
+		probe := explicit
+		if !strings.HasPrefix(probe, "/") {
+			probe = path.Join(targetPath, strings.TrimPrefix(explicit, "./"))
+		}
+		exists, err := pathExists(ctx, exec, user, probe)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			return "", fmt.Errorf("configured installCommand %q does not exist in dotfiles repo at %s", explicit, targetPath)
+		}
+		return explicit, nil
+	}
+	for _, candidate := range DefaultInstallScripts {
+		full := path.Join(targetPath, candidate)
+		exists, err := pathExists(ctx, exec, user, full)
+		if err != nil {
+			return "", err
+		}
+		if exists {
+			return candidate, nil
+		}
+	}
+	return "", nil
+}
+
+func runInstallScript(ctx context.Context, exec Executor, user, targetPath, script string) error {
+	invocation := script
+	if !strings.HasPrefix(script, "/") && !strings.HasPrefix(script, "./") {
+		invocation = "./" + script
+	}
+	// Quote the script path so a value like "install.sh; rm -rf ~" is treated
+	// as a single filename argument rather than a shell command sequence.
+	// Anything more elaborate (shell pipelines, args) belongs inside the
+	// dotfiles repo's own install script.
+	cmd := []string{"sh", "-c", fmt.Sprintf("cd %s && %s", shellQuote(targetPath), shellQuote(invocation))}
+	stdout, stderr, exitCode, err := exec.Exec(ctx, user, cmd)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		// Exit 126 means "found but not executable" and 127 means "not
+		// found / interpreter missing". Both usually point at a missing
+		// chmod +x on the script, which is the most common surprise for
+		// dotfiles repos checked out from Windows.
+		hint := ""
+		if exitCode == 126 || exitCode == 127 {
+			hint = " (hint: ensure the script is executable and its shebang interpreter exists in the container)"
+		}
+		return fmt.Errorf("install script exited with %d: stdout=%q stderr=%q%s", exitCode, stdout, stderr, hint)
+	}
+	return nil
+}
+
+// SanitizeRepoURL strips embedded credentials from an https-style URL so it
+// can be safely written to logs or error messages. Non-URL strings (ssh
+// shorthand, scp-style refs, local paths) are returned unchanged. The
+// password (if present) is also stripped along with the username.
+func SanitizeRepoURL(repo string) string {
+	return credentialURLPattern.ReplaceAllString(repo, "${1}***@")
+}
+
+// shellQuote wraps a value in single quotes for safe inclusion in `sh -c`.
+// Single quotes inside the value are handled by closing the quote, escaping
+// the literal quote, and reopening.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/pkg/dotfiles/dotfiles_test.go
+++ b/pkg/dotfiles/dotfiles_test.go
@@ -1,0 +1,455 @@
+package dotfiles
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/garaemon/devgo/pkg/config"
+)
+
+func TestResolve_Disabled(t *testing.T) {
+	got := Resolve(&config.DotfilesConfig{Repository: "https://example.com/x"}, Override{}, true)
+	if got != nil {
+		t.Errorf("expected nil when disabled, got %+v", got)
+	}
+}
+
+func TestResolve_NoRepositoryAnywhere(t *testing.T) {
+	got := Resolve(nil, Override{}, false)
+	if got != nil {
+		t.Errorf("expected nil when no repository configured, got %+v", got)
+	}
+}
+
+func TestResolve_FileOnly_DefaultsTargetPath(t *testing.T) {
+	got := Resolve(&config.DotfilesConfig{Repository: "https://example.com/x"}, Override{}, false)
+	if got == nil {
+		t.Fatalf("expected resolved config, got nil")
+	}
+	if got.Repository != "https://example.com/x" {
+		t.Errorf("Repository = %q, want %q", got.Repository, "https://example.com/x")
+	}
+	if got.TargetPath != DefaultTargetPath {
+		t.Errorf("TargetPath = %q, want %q", got.TargetPath, DefaultTargetPath)
+	}
+	if got.InstallCommand != "" {
+		t.Errorf("InstallCommand = %q, want empty (auto-detect)", got.InstallCommand)
+	}
+}
+
+func TestResolve_OverridesWinOverFile(t *testing.T) {
+	file := &config.DotfilesConfig{
+		Repository:     "https://example.com/file",
+		TargetPath:     "/file/path",
+		InstallCommand: "file.sh",
+	}
+	override := Override{
+		Repository:     "https://example.com/cli",
+		TargetPath:     "/cli/path",
+		InstallCommand: "cli.sh",
+	}
+	got := Resolve(file, override, false)
+	if got.Repository != "https://example.com/cli" {
+		t.Errorf("Repository = %q, want CLI override", got.Repository)
+	}
+	if got.TargetPath != "/cli/path" {
+		t.Errorf("TargetPath = %q, want CLI override", got.TargetPath)
+	}
+	if got.InstallCommand != "cli.sh" {
+		t.Errorf("InstallCommand = %q, want CLI override", got.InstallCommand)
+	}
+}
+
+func TestResolve_PartialOverridePreservesFile(t *testing.T) {
+	file := &config.DotfilesConfig{
+		Repository:     "https://example.com/file",
+		TargetPath:     "/file/path",
+		InstallCommand: "file.sh",
+	}
+	override := Override{Repository: "https://example.com/cli"}
+	got := Resolve(file, override, false)
+	if got.Repository != "https://example.com/cli" {
+		t.Errorf("Repository = %q, want CLI override", got.Repository)
+	}
+	if got.TargetPath != "/file/path" {
+		t.Errorf("TargetPath = %q, want file value preserved", got.TargetPath)
+	}
+	if got.InstallCommand != "file.sh" {
+		t.Errorf("InstallCommand = %q, want file value preserved", got.InstallCommand)
+	}
+}
+
+// fakeExec records every command and replies based on programmable rules.
+type fakeExec struct {
+	calls []fakeCall
+	// rules: substring of the joined command -> response
+	rules []fakeRule
+}
+
+type fakeCall struct {
+	user string
+	cmd  []string
+}
+
+type fakeRule struct {
+	contains string
+	stdout   string
+	stderr   string
+	exitCode int
+	err      error
+}
+
+func (f *fakeExec) Exec(_ context.Context, user string, cmd []string) (string, string, int, error) {
+	f.calls = append(f.calls, fakeCall{user: user, cmd: append([]string{}, cmd...)})
+	joined := strings.Join(cmd, " ")
+	for _, r := range f.rules {
+		if strings.Contains(joined, r.contains) {
+			return r.stdout, r.stderr, r.exitCode, r.err
+		}
+	}
+	return "", "", 0, nil
+}
+
+func (f *fakeExec) commandsContaining(substr string) int {
+	count := 0
+	for _, c := range f.calls {
+		if strings.Contains(strings.Join(c.cmd, " "), substr) {
+			count++
+		}
+	}
+	return count
+}
+
+func TestApply_NilConfig_NoOp(t *testing.T) {
+	exec := &fakeExec{}
+	if err := Apply(context.Background(), exec, "user", nil, false); err != nil {
+		t.Errorf("Apply(nil) error = %v, want nil", err)
+	}
+	if len(exec.calls) != 0 {
+		t.Errorf("expected no exec calls, got %d", len(exec.calls))
+	}
+}
+
+func TestApply_SkipsWhenTargetExistsAndNotForce(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: "[ -e", exitCode: 0}, // target exists
+		},
+	}
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "/home/u/df"}
+	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("git clone") != 0 {
+		t.Errorf("did not expect git clone when target exists and not force")
+	}
+}
+
+func TestApply_ForceRemovesAndReclones(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			// Probing the install scripts after clone returns "not found".
+			// First check (the targetPath itself) returns "exists".
+			{contains: "[ -e '/home/u/df'", exitCode: 0},
+			{contains: "[ -e", exitCode: 1}, // install script probes -> not found
+		},
+	}
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "/home/u/df"}
+	if err := Apply(context.Background(), exec, "u", cfg, true); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("rm -rf") != 1 {
+		t.Errorf("expected exactly 1 rm -rf call, got %d", exec.commandsContaining("rm -rf"))
+	}
+	if exec.commandsContaining("git clone") != 1 {
+		t.Errorf("expected exactly 1 git clone call, got %d", exec.commandsContaining("git clone"))
+	}
+}
+
+func TestApply_RunsExplicitInstallCommand(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+			{contains: "[ -e '/home/u/df/bootstrap.sh'", exitCode: 0}, // explicit script probe says exists
+			{contains: "[ -e", exitCode: 1},                           // target dir probe says missing
+		},
+	}
+	cfg := &Config{
+		Repository:     "https://example.com/x",
+		TargetPath:     "~/df",
+		InstallCommand: "bootstrap.sh",
+	}
+	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("./bootstrap.sh") != 1 {
+		t.Errorf("expected install command ./bootstrap.sh to run, got calls=%v", exec.calls)
+	}
+	if exec.commandsContaining("/home/u/df") == 0 {
+		t.Errorf("expected resolved path /home/u/df to appear in commands, got calls=%v", exec.calls)
+	}
+}
+
+func TestApply_FailsWhenExplicitInstallCommandMissing(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+			{contains: "[ -e", exitCode: 1}, // both target and script probe miss
+		},
+	}
+	cfg := &Config{
+		Repository:     "https://example.com/x",
+		TargetPath:     "~/df",
+		InstallCommand: "missing.sh",
+	}
+	err := Apply(context.Background(), exec, "u", cfg, false)
+	if err == nil {
+		t.Fatalf("expected Apply to error when explicit install command is missing")
+	}
+	if !strings.Contains(err.Error(), "missing.sh") {
+		t.Errorf("error %q should mention the missing script name", err.Error())
+	}
+}
+
+func TestApply_DetectsDefaultInstallScript(t *testing.T) {
+	// Simulate that target doesn't exist initially, then clone happens, then
+	// install.sh is missing but bootstrap.sh exists.
+	exec := &fakeExec{}
+	exec.rules = []fakeRule{
+		{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+		{contains: "[ -e '/home/u/df/install.sh'", exitCode: 1},
+		{contains: "[ -e '/home/u/df/install'", exitCode: 1},
+		{contains: "[ -e '/home/u/df/bootstrap.sh'", exitCode: 0},
+		{contains: "[ -e", exitCode: 1}, // target path probe and any others
+	}
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
+	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("./bootstrap.sh") != 1 {
+		t.Errorf("expected bootstrap.sh to run, got calls=%v", exec.calls)
+	}
+	if exec.commandsContaining("./install.sh") != 0 {
+		t.Errorf("did not expect install.sh to run when missing")
+	}
+}
+
+func TestResolveHome(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "no tilde returns unchanged", path: "/abs/path", want: "/abs/path"},
+		{name: "tilde alone resolves to HOME", path: "~", want: "/home/u"},
+		{name: "tilde slash prefix resolves", path: "~/dotfiles", want: "/home/u/dotfiles"},
+		{name: "tilde middle of path is left alone", path: "/etc/~user", want: "/etc/~user"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec := &fakeExec{rules: []fakeRule{{contains: "printf", stdout: "/home/u"}}}
+			got, err := resolveHome(context.Background(), exec, "u", tt.path)
+			if err != nil {
+				t.Fatalf("resolveHome error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("resolveHome(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeRepoURL(t *testing.T) {
+	cases := map[string]string{
+		"https://alice:secret@github.com/x/y": "https://***@github.com/x/y",
+		"https://github.com/x/y":              "https://github.com/x/y",
+		"git@github.com:x/y.git":              "git@github.com:x/y.git",
+		"":                                    "",
+	}
+	for input, want := range cases {
+		got := SanitizeRepoURL(input)
+		if got != want {
+			t.Errorf("SanitizeRepoURL(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestCloneRepo_RedactsCredentialsInErrorMessage(t *testing.T) {
+	repo := "https://alice:secret@github.com/x/y"
+	exec := &fakeExec{rules: []fakeRule{
+		{
+			contains: "git clone",
+			stderr:   "fatal: could not read from " + repo,
+			exitCode: 128,
+		},
+	}}
+	err := cloneRepo(context.Background(), exec, "u", repo, "/tmp/x")
+	if err == nil {
+		t.Fatalf("expected error from cloneRepo, got nil")
+	}
+	if strings.Contains(err.Error(), "secret") {
+		t.Errorf("error message leaks credential: %v", err)
+	}
+	if !strings.Contains(err.Error(), "***") {
+		t.Errorf("error message should contain redaction marker (***): %v", err)
+	}
+}
+
+func TestResolveHome_RejectsOtherUserForm(t *testing.T) {
+	exec := &fakeExec{}
+	_, err := resolveHome(context.Background(), exec, "u", "~someone/dotfiles")
+	if err == nil {
+		t.Fatalf("expected error for ~someone/... path, got nil")
+	}
+	if !strings.Contains(err.Error(), "~user form") {
+		t.Errorf("error %q does not mention unsupported ~user form", err.Error())
+	}
+}
+
+func TestApply_RejectsOtherUserPath(t *testing.T) {
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~someone/df"}
+	err := Apply(context.Background(), &fakeExec{}, "u", cfg, false)
+	if err == nil {
+		t.Fatalf("expected wrapped ~user error from Apply, got nil")
+	}
+	if !strings.Contains(err.Error(), "~user form") {
+		t.Errorf("Apply error %q should propagate the ~user diagnostic", err.Error())
+	}
+}
+
+func TestApply_PropagatesInstallScriptFailure(t *testing.T) {
+	exec := &fakeExec{rules: []fakeRule{
+		{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+		{contains: "[ -e '/home/u/df/install.sh'", exitCode: 0},
+		{contains: "[ -e", exitCode: 1},
+		{contains: "&& './install.sh'", stdout: "starting", stderr: "boom", exitCode: 2},
+	}}
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
+	err := Apply(context.Background(), exec, "u", cfg, false)
+	if err == nil {
+		t.Fatalf("expected install script error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exited with 2") {
+		t.Errorf("error should include exit code, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error should include stderr content, got %v", err)
+	}
+}
+
+func TestApply_InstallScriptExit126_AddsExecutableHint(t *testing.T) {
+	exec := &fakeExec{rules: []fakeRule{
+		{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+		{contains: "[ -e '/home/u/df/install.sh'", exitCode: 0},
+		{contains: "[ -e", exitCode: 1},
+		{contains: "&& './install.sh'", stderr: "Permission denied", exitCode: 126},
+	}}
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
+	err := Apply(context.Background(), exec, "u", cfg, false)
+	if err == nil {
+		t.Fatalf("expected error for exit 126, got nil")
+	}
+	if !strings.Contains(err.Error(), "executable") {
+		t.Errorf("exit 126 should trigger executable-bit hint, got %v", err)
+	}
+}
+
+func TestDefaultTargetPath_IsSubdirectoryOfHome(t *testing.T) {
+	if DefaultTargetPath != "~/dotfiles" {
+		t.Errorf("DefaultTargetPath = %q, want %q (clone into a subdir, not $HOME)", DefaultTargetPath, "~/dotfiles")
+	}
+}
+
+// TestApply_NeverPassesUnresolvedTilde is a regression test for the bug
+// where shell-quoted paths like `'~'` would not be expanded by the inner
+// shell, causing devgo to create a literal "~" directory in the container.
+// After Apply runs, no command (other than the HOME probe itself) may
+// contain a single-quoted tilde.
+func TestApply_NeverPassesUnresolvedTilde(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+			{contains: "[ -e", exitCode: 1},
+		},
+	}
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/dotfiles"}
+	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	for i, c := range exec.calls {
+		joined := strings.Join(c.cmd, " ")
+		if strings.Contains(joined, `printf %s "$HOME"`) {
+			continue
+		}
+		if strings.Contains(joined, "'~") {
+			t.Errorf("call %d still contains unresolved tilde-quoted path: %v", i, c.cmd)
+		}
+	}
+}
+
+// TestApply_DefaultConfig_DoesNotCloneIntoBareHome is a regression test for
+// the bug where DefaultTargetPath was "~", which made git clone target
+// $HOME directly. Cloning into a non-empty directory fails. The default
+// must be a subdirectory.
+func TestApply_DefaultConfig_DoesNotCloneIntoBareHome(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+			{contains: "[ -e", exitCode: 1},
+		},
+	}
+	resolved := Resolve(&config.DotfilesConfig{Repository: "https://example.com/x"}, Override{}, false)
+	if resolved == nil {
+		t.Fatalf("Resolve returned nil")
+	}
+	if err := Apply(context.Background(), exec, "u", resolved, false); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("git clone") == 0 {
+		t.Fatalf("expected git clone to run, got none")
+	}
+	for _, c := range exec.calls {
+		joined := strings.Join(c.cmd, " ")
+		if !strings.Contains(joined, "git clone") {
+			continue
+		}
+		// The clone target must not be the bare HOME directory.
+		if strings.Contains(joined, "'/home/u'") {
+			t.Errorf("git clone targeted bare $HOME, must clone into a subdir: %v", c.cmd)
+		}
+		if !strings.Contains(joined, "'/home/u/dotfiles'") {
+			t.Errorf("expected clone target /home/u/dotfiles, got: %v", c.cmd)
+		}
+	}
+}
+
+func TestApply_NoInstallScriptFound_LeavesCloneInPlace(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: "[ -e", exitCode: 1}, // every existence check fails
+		},
+	}
+	cfg := &Config{Repository: "https://example.com/x", TargetPath: "/home/u/df"}
+	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("git clone") != 1 {
+		t.Errorf("expected clone to happen, got %d", exec.commandsContaining("git clone"))
+	}
+	for _, c := range exec.calls {
+		joined := strings.Join(c.cmd, " ")
+		if strings.Contains(joined, "cd ") && strings.Contains(joined, " && ./") {
+			t.Errorf("did not expect any install command to run, got %v", c.cmd)
+		}
+	}
+}
+
+func TestShellQuote_HandlesEmbeddedQuote(t *testing.T) {
+	got := shellQuote("a'b")
+	want := `'a'\''b'`
+	if got != want {
+		t.Errorf("shellQuote(%q) = %q, want %q", "a'b", got, want)
+	}
+}
+


### PR DESCRIPTION
## Summary

This branch adds **per-user customization** to devgo so individuals can keep their own shell setup separate from the team's `devcontainer.json`:

- **Personal dotfiles** support (`pkg/dotfiles`, `cmd/dotfiles_*.go`, [`docs/dotfiles.md`](docs/dotfiles.md)) — VS Code-compatible `repository` / `targetPath` / `installCommand`, loaded from `~/.config/devgo/config.json`. CLI overrides via `--dotfiles-repository`, `--dotfiles-target-path`, `--dotfiles-install-command`, `--no-dotfiles`, `--force-dotfiles`. Credential-redacted logs/errors, `~`-expanded against the container's `$HOME`, and exit-126/127 hints when an install script is missing `+x`.
- **Shell override** — `UserConfig.Shell` and the `--shell` flag let `devgo shell` honor a personal default (e.g. `zsh`) without touching the team's `devcontainer.json`. Falls back to `/bin/bash`.
- **`exec`/`shell` user fix** — both commands now use `GetTargetUser()` (`remoteUser` → `containerUser` → `root`) instead of `GetContainerUser()`, matching the user lifecycle commands and dotfiles install run as. Previously, dotfiles installed for `vscode` were invisible from `devgo exec`/`devgo shell` because both ran as `root`.

Also includes a project dev container at `.devcontainer/devcontainer.json` (Go 1.24 image + `updateRemoteUserUID`) and a small in-place lint cleanup in `createComposeOverrideFile`.

Reviewed across five iterations of `/code-review-loop`; security (credential leakage, shell injection), correctness (exit code handling, `~` expansion), and test coverage (regression tests for every fix) were addressed.

## Test plan

- [x] `make ci` passes (lint + unit tests + build)
- [x] `make test-integration` passes against a real Docker daemon
- [x] Manual: configure `~/.config/devgo/config.json` with a dotfiles repo, run `devgo up`, confirm `devgo shell` lands in the personalized environment as `remoteUser`
- [x] Manual: `devgo up --no-dotfiles` skips the dotfiles step
- [ ] Manual: `devgo up --force-dotfiles` re-clones over an existing target
- [x] Manual: `devgo shell --shell zsh` launches `zsh` even without changing the config file

🤖 Generated with [Claude Code](https://claude.com/claude-code)