### PR TITLE
Ignore coverage artifacts produced by make test-coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 devgo
+
+# Test coverage artifacts produced by `make test-coverage`
+# (matches coverage.out, coverage.html, and ad-hoc variants like
+# coverage_final.out, coverage_updatecontent.html, etc.)
+coverage*.out
+coverage*.html

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 devgo
 
-# Test coverage artifacts produced by `make test-coverage`
-# (matches coverage.out, coverage.html, and ad-hoc variants like
-# coverage_final.out, coverage_updatecontent.html, etc.)
+# Test coverage artifacts produced by `make test-coverage` and ad-hoc
+# variants accumulated during iterative testing
+# (e.g. coverage_final.out, coverage_updatecontent.html).
+coverage.out
+coverage.html
 coverage*.out
 coverage*.html


### PR DESCRIPTION
## Summary

- `make test-coverage` writes `coverage.out` and `coverage.html` into the repo root every run, so they show up as untracked files.
- Ad-hoc variants (`coverage_final.out`, `coverage_updatecontent.html`, `coverage_down*.out`, `coverage_new.out`) accumulate when iterating on a feature.
- Add `coverage*.out` and `coverage*.html` to `.gitignore` so they stop polluting `git status` and can't be committed accidentally.

## Test plan

- [x] Run `make test-coverage` and confirm the resulting files do not appear in `git status`
- [x] Confirm the existing `devgo` binary entry still works (binary still ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)