### PR TITLE
Quiet devgo by default and gate progress behind --debug

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -21,9 +21,7 @@ func runBuildCommand(args []string) error {
 		return fmt.Errorf("failed to find devcontainer config: %w", err)
 	}
 
-	if verbose {
-		fmt.Printf("Using devcontainer config: %s\n", devcontainerPath)
-	}
+	debugf("Using devcontainer config: %s\n", devcontainerPath)
 
 	devContainer, err := devcontainer.Parse(devcontainerPath)
 	if err != nil {
@@ -43,11 +41,9 @@ func buildDevContainer(devContainer *devcontainer.DevContainer, workspaceDir, de
 
 	imageTag := determineImageTag(devContainer, workspaceDir)
 
-	if verbose {
-		fmt.Printf("Building image: %s\n", imageTag)
-		fmt.Printf("Dockerfile: %s\n", dockerfilePath)
-		fmt.Printf("Build context: %s\n", buildContext)
-	}
+	debugf("Building image: %s\n", imageTag)
+	debugf("Dockerfile: %s\n", dockerfilePath)
+	debugf("Build context: %s\n", buildContext)
 
 	buildArgs := []string{"build", "-t", imageTag, "-f", dockerfilePath}
 
@@ -81,15 +77,13 @@ func buildDevContainer(devContainer *devcontainer.DevContainer, workspaceDir, de
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	if verbose {
-		fmt.Printf("Running: docker %s\n", strings.Join(buildArgs, " "))
-	}
+	debugf("Running: docker %s\n", strings.Join(buildArgs, " "))
 
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("docker build failed: %w", err)
 	}
 
-	fmt.Printf("Successfully built image: %s\n", imageTag)
+	debugf("Successfully built image: %s\n", imageTag)
 
 	if push {
 		return pushImage(imageTag)
@@ -135,9 +129,7 @@ func determineImageTag(devContainer *devcontainer.DevContainer, workspaceDir str
 }
 
 func pushImage(imageTag string) error {
-	if verbose {
-		fmt.Printf("Pushing image: %s\n", imageTag)
-	}
+	debugf("Pushing image: %s\n", imageTag)
 
 	cmd := exec.Command("docker", "push", imageTag)
 	cmd.Stdout = os.Stdout
@@ -147,7 +139,7 @@ func pushImage(imageTag string) error {
 		return fmt.Errorf("docker push failed: %w", err)
 	}
 
-	fmt.Printf("Successfully pushed image: %s\n", imageTag)
+	debugf("Successfully pushed image: %s\n", imageTag)
 	return nil
 }
 

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -40,7 +40,7 @@ func runDownCommand(args []string) error {
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -80,27 +80,27 @@ func stopAndRemoveContainer(ctx context.Context, cli DownDockerClient, container
 	}
 
 	if !found {
-		fmt.Printf("Container '%s' does not exist\n", containerName)
+		debugf("Container '%s' does not exist\n", containerName)
 		return nil
 	}
 
 	// Stop container if it's running
 	if isRunning {
-		fmt.Printf("Stopping container '%s'\n", containerName)
+		debugf("Stopping container '%s'\n", containerName)
 		err = cli.ContainerStop(ctx, containerID, container.StopOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to stop container '%s': %w", containerName, err)
 		}
-		fmt.Printf("Container '%s' stopped\n", containerName)
+		debugf("Container '%s' stopped\n", containerName)
 	}
 
 	// Remove container
-	fmt.Printf("Removing container '%s'\n", containerName)
+	debugf("Removing container '%s'\n", containerName)
 	err = cli.ContainerRemove(ctx, containerID, container.RemoveOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to remove container '%s': %w", containerName, err)
 	}
 
-	fmt.Printf("Container '%s' removed successfully\n", containerName)
+	debugf("Container '%s' removed successfully\n", containerName)
 	return nil
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -51,7 +51,7 @@ func runExecCommand(args []string) error {
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,9 +15,7 @@ func runInitCommand(args []string) error {
 		return fmt.Errorf("failed to determine target directory: %w", err)
 	}
 
-	if verbose {
-		fmt.Printf("Target directory: %s\n", targetDir)
-	}
+	debugf("Target directory: %s\n", targetDir)
 
 	// Create .devcontainer directory
 	devcontainerDir := filepath.Join(targetDir, ".devcontainer")
@@ -69,9 +67,7 @@ func determineInitDirectory(args []string) (string, error) {
 	gitRoot, err := findGitRoot()
 	if err != nil {
 		// If not in a git repository, use current directory
-		if verbose {
-			fmt.Fprintf(os.Stderr, "Warning: not in a git repository, using current directory\n")
-		}
+		debugf("Warning: not in a git repository, using current directory\n")
 		cwd, err := os.Getwd()
 		if err != nil {
 			return "", fmt.Errorf("failed to get current directory: %w", err)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -346,28 +346,28 @@ func TestInitCommandIntegration(t *testing.T) {
 	}
 }
 
-func TestInitCommandWithVerbose(t *testing.T) {
-	// Test that verbose flag works (doesn't cause errors)
-	tempDir, err := os.MkdirTemp("", "devgo-test-verbose")
+func TestInitCommandWithDebug(t *testing.T) {
+	// Test that the debug flag works (doesn't cause errors)
+	tempDir, err := os.MkdirTemp("", "devgo-test-debug")
 	if err != nil {
 		t.Fatalf("failed to create temp dir: %v", err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	// Save and restore verbose flag
-	originalVerbose := verbose
-	defer func() { verbose = originalVerbose }()
+	// Save and restore debug flag
+	originalDebug := debug
+	defer func() { debug = originalDebug }()
 
-	verbose = true
+	debug = true
 	err = runInitCommand([]string{tempDir})
 	if err != nil {
-		t.Errorf("init with verbose flag failed: %v", err)
+		t.Errorf("init with debug flag failed: %v", err)
 	}
 
 	// Verify file was created
 	devcontainerPath := filepath.Join(tempDir, ".devcontainer", "devcontainer.json")
 	if _, err := os.Stat(devcontainerPath); os.IsNotExist(err) {
-		t.Error("expected devcontainer.json to be created with verbose flag")
+		t.Error("expected devcontainer.json to be created with debug flag")
 	}
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,7 +27,7 @@ func runListCommand(args []string) error {
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,7 +23,7 @@ var (
 	sessionName            string
 	push                   bool
 	pull                   bool
-	verbose                bool
+	debug                  bool
 	showHelp               bool
 	showVersion            bool
 	dotfilesRepository     string
@@ -44,8 +44,8 @@ func parseAllFlags(args []string) ([]string, error) {
 			showHelp = true
 		} else if arg == "--version" {
 			showVersion = true
-		} else if arg == "--verbose" {
-			verbose = true
+		} else if arg == "--debug" || arg == "--verbose" {
+			debug = true
 		} else if arg == "--workspace-folder" && i+1 < len(args) {
 			workspaceFolder = args[i+1]
 			i++ // skip the next argument as it's the value
@@ -149,8 +149,28 @@ func Execute() error {
 // warnf prints a "Warning: ..." message to stderr. Use this for non-fatal
 // problems where the command continues; reserve stdout for the command's
 // real output so warnings don't pollute pipelines.
-func warnf(format string, args ...interface{}) {
+func warnf(format string, args ...any) {
 	fmt.Fprintf(os.Stderr, "Warning: "+format+"\n", args...)
+}
+
+// debugf writes a status/progress message to stderr only when --debug is
+// enabled. Use this for informational logs that would clutter normal output
+// (container lifecycle, image pulls, dotfiles progress, etc.).
+func debugf(format string, args ...any) {
+	if !debug {
+		return
+	}
+	fmt.Fprintf(os.Stderr, format, args...)
+}
+
+// debugln writes a line of status/progress to stderr only when --debug is
+// enabled. Counterpart to debugf for callers that just want to emit a fixed
+// string without formatting.
+func debugln(args ...any) {
+	if !debug {
+		return
+	}
+	fmt.Fprintln(os.Stderr, args...)
 }
 
 func showUsage() {
@@ -174,6 +194,10 @@ Commands:
 Flags:
   --config string
         Path to devcontainer.json file
+  --debug
+        Print container lifecycle, dotfiles, and other progress messages
+        to stderr. Without this flag devgo stays quiet on success.
+        --verbose is accepted as a deprecated alias.
   --force-build
         Force rebuild of container
   --help
@@ -188,8 +212,6 @@ Flags:
         Force pull image before starting container
   --session string
         Session name for running multiple containers (default "default")
-  --verbose
-        Enable verbose output
   --version
         Show version
   --workspace-folder string
@@ -222,15 +244,15 @@ func showVersionInfo() {
 
 func runDevContainer(args []string) error {
 	// TODO: Implement actual functionality
-	fmt.Printf("devgo called with args: %v\n", args)
-	fmt.Printf("config: %s, build: %t, name: %s\n", configPath, forceBuild, containerName)
+	debugf("devgo called with args: %v\n", args)
+	debugf("config: %s, build: %t, name: %s\n", configPath, forceBuild, containerName)
 
 	devcontainerPath, err := findDevcontainerConfig(configPath)
 	if err != nil {
 		return fmt.Errorf("failed to find devcontainer config: %w", err)
 	}
 
-	fmt.Printf("Found devcontainer config at: %s\n", devcontainerPath)
+	debugf("Found devcontainer config at: %s\n", devcontainerPath)
 	return nil
 }
 
@@ -245,9 +267,7 @@ func findDevcontainerConfig(configPath string) (string, error) {
 	}
 
 	for dir := cwd; dir != "/"; dir = filepath.Dir(dir) {
-		if verbose {
-			fmt.Printf("Checking directory: %s\n", dir)
-		}
+		debugf("Checking directory: %s\n", dir)
 
 		configFile := filepath.Join(dir, ".devcontainer", "devcontainer.json")
 		if _, err := os.Stat(configFile); err == nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -70,7 +70,7 @@ func TestParseAllFlags(t *testing.T) {
 			// Reset global flags before each test
 			showHelp = false
 			showVersion = false
-			verbose = false
+			debug = false
 			workspaceFolder = ""
 			configPath = ""
 			containerName = ""
@@ -115,7 +115,7 @@ func TestParseAllFlags_FlagValues(t *testing.T) {
 		expectForceBuild      bool
 		expectPush            bool
 		expectPull            bool
-		expectVerbose         bool
+		expectDebug           bool
 		expectHelp            bool
 		expectVersion         bool
 	}{
@@ -160,9 +160,14 @@ func TestParseAllFlags_FlagValues(t *testing.T) {
 			expectPull: true,
 		},
 		{
-			name:          "verbose flag",
-			args:          []string{"--verbose"},
-			expectVerbose: true,
+			name:        "debug flag",
+			args:        []string{"--debug"},
+			expectDebug: true,
+		},
+		{
+			name:        "verbose alias still enables debug",
+			args:        []string{"--verbose"},
+			expectDebug: true,
 		},
 		{
 			name:       "help flag",
@@ -180,12 +185,12 @@ func TestParseAllFlags_FlagValues(t *testing.T) {
 				"--workspace-folder", "/test",
 				"--config", "config.json",
 				"--force-build",
-				"--verbose",
+				"--debug",
 			},
 			expectWorkspaceFolder: "/test",
 			expectConfigPath:      "config.json",
 			expectForceBuild:      true,
-			expectVerbose:         true,
+			expectDebug:           true,
 		},
 	}
 
@@ -194,7 +199,7 @@ func TestParseAllFlags_FlagValues(t *testing.T) {
 			// Reset global flags before each test
 			showHelp = false
 			showVersion = false
-			verbose = false
+			debug = false
 			workspaceFolder = ""
 			configPath = ""
 			containerName = ""
@@ -234,8 +239,8 @@ func TestParseAllFlags_FlagValues(t *testing.T) {
 			if pull != tt.expectPull {
 				t.Errorf("pull = %v, want %v", pull, tt.expectPull)
 			}
-			if verbose != tt.expectVerbose {
-				t.Errorf("verbose = %v, want %v", verbose, tt.expectVerbose)
+			if debug != tt.expectDebug {
+				t.Errorf("debug = %v, want %v", debug, tt.expectDebug)
 			}
 			if showHelp != tt.expectHelp {
 				t.Errorf("showHelp = %v, want %v", showHelp, tt.expectHelp)

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -111,9 +111,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		width, height, err := term.GetSize(stdinFd)
 		if err == nil {
 			consoleSize = &[2]uint{uint(height), uint(width)}
-			if debug {
-				fmt.Printf("Terminal size: %dx%d (cols x rows)\n", width, height)
-			}
+			debugf("Terminal size: %dx%d (cols x rows)\n", width, height)
 		}
 	}
 
@@ -130,52 +128,44 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		DetachKeys:   "ctrl-@", // Use ctrl-@ instead of default ctrl-p,ctrl-q to allow ctrl-p for history
 	}
 
-	if debug {
-		fmt.Printf("Creating exec instance with config:\n")
-		fmt.Printf("  User: %s\n", user)
-		fmt.Printf("  Tty: %v\n", execConfig.Tty)
-		fmt.Printf("  AttachStdin: %v\n", execConfig.AttachStdin)
-		fmt.Printf("  AttachStdout: %v\n", execConfig.AttachStdout)
-		fmt.Printf("  AttachStderr: %v\n", execConfig.AttachStderr)
-		fmt.Printf("  Cmd: %v\n", execConfig.Cmd)
-		fmt.Printf("  Env: %v\n", execConfig.Env)
-		fmt.Printf("  DetachKeys: %s (allows ctrl-p for history)\n", execConfig.DetachKeys)
-		if consoleSize != nil {
-			fmt.Printf("  ConsoleSize: %dx%d\n", consoleSize[1], consoleSize[0])
-		}
-		fmt.Printf("  WorkingDir: %s\n", execConfig.WorkingDir)
-		fmt.Printf("  Container ID: %s\n", containerID)
+	debugln("Creating exec instance with config:")
+	debugf("  User: %s\n", user)
+	debugf("  Tty: %v\n", execConfig.Tty)
+	debugf("  AttachStdin: %v\n", execConfig.AttachStdin)
+	debugf("  AttachStdout: %v\n", execConfig.AttachStdout)
+	debugf("  AttachStderr: %v\n", execConfig.AttachStderr)
+	debugf("  Cmd: %v\n", execConfig.Cmd)
+	debugf("  Env: %v\n", execConfig.Env)
+	debugf("  DetachKeys: %s (allows ctrl-p for history)\n", execConfig.DetachKeys)
+	if consoleSize != nil {
+		debugf("  ConsoleSize: %dx%d\n", consoleSize[1], consoleSize[0])
 	}
+	debugf("  WorkingDir: %s\n", execConfig.WorkingDir)
+	debugf("  Container ID: %s\n", containerID)
 
 	execCreateResp, err := cli.ContainerExecCreate(ctx, containerID, execConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create exec instance: %w", err)
 	}
 
-	if debug {
-		fmt.Printf("Exec instance created with ID: %s\n", execCreateResp.ID)
-	}
+	debugf("Exec instance created with ID: %s\n", execCreateResp.ID)
 
 	// Check if stdin is a terminal and set raw mode
 	var oldState *term.State
 	if term.IsTerminal(stdinFd) {
-		if debug {
-			fmt.Printf("Setting terminal to raw mode (fd: %d)\n", stdinFd)
-		}
+		debugf("Setting terminal to raw mode (fd: %d)\n", stdinFd)
 		oldState, err = term.MakeRaw(stdinFd)
 		if err != nil {
 			return fmt.Errorf("failed to set terminal to raw mode: %w", err)
 		}
-		if debug {
-			fmt.Printf("Terminal set to raw mode successfully\n")
-		}
+		debugln("Terminal set to raw mode successfully")
 		defer func() {
 			if restoreErr := term.Restore(stdinFd, oldState); restoreErr != nil {
 				warnf("failed to restore terminal: %v", restoreErr)
 			}
 		}()
-	} else if debug {
-		fmt.Printf("Warning: stdin is not a terminal (fd: %d)\n", stdinFd)
+	} else {
+		debugf("Warning: stdin is not a terminal (fd: %d)\n", stdinFd)
 	}
 
 	// Handle signals to restore terminal state
@@ -190,9 +180,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 	}()
 
 	// Attach to the exec instance to get HijackedResponse
-	if debug {
-		fmt.Printf("Attaching to exec instance %s\n", execCreateResp.ID)
-	}
+	debugf("Attaching to exec instance %s\n", execCreateResp.ID)
 	execAttachResp, err := cli.ContainerExecAttach(ctx, execCreateResp.ID, container.ExecAttachOptions{
 		Tty: true,
 	})
@@ -200,60 +188,42 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		return fmt.Errorf("failed to attach to exec instance: %w", err)
 	}
 	defer execAttachResp.Close()
-	if debug {
-		fmt.Printf("Successfully attached to exec instance\n")
-	}
+	debugln("Successfully attached to exec instance")
 
 	// Start the exec instance in a separate goroutine
 	// This must be done AFTER attach and runs concurrently with I/O
-	if debug {
-		fmt.Printf("Starting exec instance in background\n")
-	}
+	debugln("Starting exec instance in background")
 	go func() {
 		startErr := cli.ContainerExecStart(ctx, execCreateResp.ID, container.ExecStartOptions{
 			Tty: true,
 		})
-		if debug {
-			if startErr != nil {
-				fmt.Printf("ExecStart error: %v\n", startErr)
-			} else {
-				fmt.Printf("ExecStart completed\n")
-			}
+		if startErr != nil {
+			debugf("ExecStart error: %v\n", startErr)
+		} else {
+			debugln("ExecStart completed")
 		}
 	}()
 
 	// Handle TTY I/O
-	if debug {
-		fmt.Printf("Starting I/O operations\n")
-	}
+	debugln("Starting I/O operations")
 
 	// Copy stdin to container in background
 	go func() {
-		if debug {
-			fmt.Printf("Starting stdin -> container copy\n")
-		}
+		debugln("Starting stdin -> container copy")
 		_, _ = io.Copy(execAttachResp.Conn, os.Stdin)
-		if debug {
-			fmt.Printf("Stdin copy completed\n")
-		}
+		debugln("Stdin copy completed")
 	}()
 
 	// Copy container output to stdout (blocks until exec finishes)
-	if debug {
-		fmt.Printf("Starting container -> stdout copy (blocking)\n")
-	}
+	debugln("Starting container -> stdout copy (blocking)")
 	_, err = io.Copy(os.Stdout, execAttachResp.Reader)
-	if debug {
-		fmt.Printf("Stdout copy completed: err=%v\n", err)
-	}
+	debugf("Stdout copy completed: err=%v\n", err)
 
 	if err != nil && err != io.EOF {
 		return fmt.Errorf("failed to handle interactive session: %w", err)
 	}
 
-	if debug {
-		fmt.Printf("Shell session completed successfully\n")
-	}
+	debugln("Shell session completed successfully")
 
 	return nil
 }

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -54,7 +54,7 @@ func runShellCommand(args []string) error {
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -111,7 +111,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		width, height, err := term.GetSize(stdinFd)
 		if err == nil {
 			consoleSize = &[2]uint{uint(height), uint(width)}
-			if verbose {
+			if debug {
 				fmt.Printf("Terminal size: %dx%d (cols x rows)\n", width, height)
 			}
 		}
@@ -130,7 +130,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		DetachKeys:   "ctrl-@", // Use ctrl-@ instead of default ctrl-p,ctrl-q to allow ctrl-p for history
 	}
 
-	if verbose {
+	if debug {
 		fmt.Printf("Creating exec instance with config:\n")
 		fmt.Printf("  User: %s\n", user)
 		fmt.Printf("  Tty: %v\n", execConfig.Tty)
@@ -152,29 +152,29 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		return fmt.Errorf("failed to create exec instance: %w", err)
 	}
 
-	if verbose {
+	if debug {
 		fmt.Printf("Exec instance created with ID: %s\n", execCreateResp.ID)
 	}
 
 	// Check if stdin is a terminal and set raw mode
 	var oldState *term.State
 	if term.IsTerminal(stdinFd) {
-		if verbose {
+		if debug {
 			fmt.Printf("Setting terminal to raw mode (fd: %d)\n", stdinFd)
 		}
 		oldState, err = term.MakeRaw(stdinFd)
 		if err != nil {
 			return fmt.Errorf("failed to set terminal to raw mode: %w", err)
 		}
-		if verbose {
+		if debug {
 			fmt.Printf("Terminal set to raw mode successfully\n")
 		}
 		defer func() {
 			if restoreErr := term.Restore(stdinFd, oldState); restoreErr != nil {
-				fmt.Printf("Warning: failed to restore terminal: %v\n", restoreErr)
+				warnf("failed to restore terminal: %v", restoreErr)
 			}
 		}()
-	} else if verbose {
+	} else if debug {
 		fmt.Printf("Warning: stdin is not a terminal (fd: %d)\n", stdinFd)
 	}
 
@@ -190,7 +190,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 	}()
 
 	// Attach to the exec instance to get HijackedResponse
-	if verbose {
+	if debug {
 		fmt.Printf("Attaching to exec instance %s\n", execCreateResp.ID)
 	}
 	execAttachResp, err := cli.ContainerExecAttach(ctx, execCreateResp.ID, container.ExecAttachOptions{
@@ -200,20 +200,20 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		return fmt.Errorf("failed to attach to exec instance: %w", err)
 	}
 	defer execAttachResp.Close()
-	if verbose {
+	if debug {
 		fmt.Printf("Successfully attached to exec instance\n")
 	}
 
 	// Start the exec instance in a separate goroutine
 	// This must be done AFTER attach and runs concurrently with I/O
-	if verbose {
+	if debug {
 		fmt.Printf("Starting exec instance in background\n")
 	}
 	go func() {
 		startErr := cli.ContainerExecStart(ctx, execCreateResp.ID, container.ExecStartOptions{
 			Tty: true,
 		})
-		if verbose {
+		if debug {
 			if startErr != nil {
 				fmt.Printf("ExecStart error: %v\n", startErr)
 			} else {
@@ -223,27 +223,27 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 	}()
 
 	// Handle TTY I/O
-	if verbose {
+	if debug {
 		fmt.Printf("Starting I/O operations\n")
 	}
 
 	// Copy stdin to container in background
 	go func() {
-		if verbose {
+		if debug {
 			fmt.Printf("Starting stdin -> container copy\n")
 		}
 		_, _ = io.Copy(execAttachResp.Conn, os.Stdin)
-		if verbose {
+		if debug {
 			fmt.Printf("Stdin copy completed\n")
 		}
 	}()
 
 	// Copy container output to stdout (blocks until exec finishes)
-	if verbose {
+	if debug {
 		fmt.Printf("Starting container -> stdout copy (blocking)\n")
 	}
 	_, err = io.Copy(os.Stdout, execAttachResp.Reader)
-	if verbose {
+	if debug {
 		fmt.Printf("Stdout copy completed: err=%v\n", err)
 	}
 
@@ -251,7 +251,7 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 		return fmt.Errorf("failed to handle interactive session: %w", err)
 	}
 
-	if verbose {
+	if debug {
 		fmt.Printf("Shell session completed successfully\n")
 	}
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -32,7 +32,7 @@ func runStopCommand(args []string) error {
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -67,16 +67,16 @@ func stopContainer(ctx context.Context, cli *client.Client, containerName string
 	}
 
 	if !found {
-		fmt.Printf("Container '%s' is not running\n", containerName)
+		debugf("Container '%s' is not running\n", containerName)
 		return nil
 	}
 
-	fmt.Printf("Stopping container '%s'\n", containerName)
+	debugf("Stopping container '%s'\n", containerName)
 	err = cli.ContainerStop(ctx, containerName, container.StopOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to stop container '%s': %w", containerName, err)
 	}
 
-	fmt.Printf("Container '%s' stopped successfully\n", containerName)
+	debugf("Container '%s' stopped successfully\n", containerName)
 	return nil
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -99,7 +99,7 @@ func runUpCommand(args []string) error {
 	}
 	defer func() {
 		if closeErr := dockerClient.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -127,7 +127,7 @@ func startContainerWithDocker(ctx context.Context, devContainer *devcontainer.De
 			return fmt.Errorf("failed to find devcontainer config: %w", err)
 		}
 
-		fmt.Println("No image specified, building from Dockerfile...")
+		debugln("No image specified, building from Dockerfile...")
 		if err := buildDevContainer(devContainer, workspaceDir, devcontainerPath); err != nil {
 			return fmt.Errorf("failed to build dev container: %w", err)
 		}
@@ -160,9 +160,9 @@ func startContainerWithDocker(ctx context.Context, devContainer *devcontainer.De
 	// Pull image if needed
 	if shouldPullImage {
 		if pull {
-			fmt.Printf("Pulling image '%s'\n", devContainer.Image)
+			debugf("Pulling image '%s'\n", devContainer.Image)
 		} else {
-			fmt.Printf("Image '%s' not found locally, pulling...\n", devContainer.Image)
+			debugf("Image '%s' not found locally, pulling...\n", devContainer.Image)
 		}
 		if err := dockerClient.PullImage(ctx, devContainer.Image); err != nil {
 			return fmt.Errorf("failed to pull image '%s': %w", devContainer.Image, err)
@@ -183,7 +183,7 @@ func startContainerWithDocker(ctx context.Context, devContainer *devcontainer.De
 		if running {
 			return fmt.Errorf("container '%s' is already running", containerName)
 		}
-		fmt.Printf("Container '%s' exists but is stopped, removing and recreating it to apply configuration changes\n", containerName)
+		debugf("Container '%s' exists but is stopped, removing and recreating it to apply configuration changes\n", containerName)
 		
 		// Use raw docker client to remove the container
 		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
@@ -196,13 +196,13 @@ func startContainerWithDocker(ctx context.Context, devContainer *devcontainer.De
 	// Get base environment variables from image for expansion
 	baseEnv, err := getImageEnv(ctx, devContainer.Image)
 	if err != nil {
-		fmt.Printf("Warning: failed to get base environment variables from image: %v\n", err)
+		warnf("failed to get base environment variables from image: %v", err)
 		baseEnv = make(map[string]string)
 	}
 
 	expandedEnv := devContainer.GetContainerEnv(baseEnv)
 
-	fmt.Printf("Creating and starting container '%s' with image '%s'\n", containerName, devContainer.Image)
+	debugf("Creating and starting container '%s' with image '%s'\n", containerName, devContainer.Image)
 
 	dockerArgs := DockerRunArgs{
 		Name:            containerName,
@@ -225,7 +225,7 @@ func executeOnCreateCommand(ctx context.Context, devContainer *devcontainer.DevC
 		return nil
 	}
 
-	fmt.Printf("Running onCreateCommand: %s\n", strings.Join(onCreateArgs, " "))
+	debugf("Running onCreateCommand: %s\n", strings.Join(onCreateArgs, " "))
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -233,7 +233,7 @@ func executeOnCreateCommand(ctx context.Context, devContainer *devcontainer.DevC
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -241,7 +241,7 @@ func executeOnCreateCommand(ctx context.Context, devContainer *devcontainer.DevC
 		return err
 	}
 
-	fmt.Println("Finished onCreateCommand")
+	debugln("Finished onCreateCommand")
 	return nil
 }
 
@@ -251,7 +251,7 @@ func executeUpdateContentCommand(ctx context.Context, devContainer *devcontainer
 		return nil
 	}
 
-	fmt.Printf("Running updateContentCommand: %s\n", strings.Join(updateContentArgs, " "))
+	debugf("Running updateContentCommand: %s\n", strings.Join(updateContentArgs, " "))
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -259,7 +259,7 @@ func executeUpdateContentCommand(ctx context.Context, devContainer *devcontainer
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -267,7 +267,7 @@ func executeUpdateContentCommand(ctx context.Context, devContainer *devcontainer
 		return err
 	}
 
-	fmt.Println("Finished updateContentCommand")
+	debugln("Finished updateContentCommand")
 	return nil
 }
 
@@ -277,7 +277,7 @@ func executePostCreateCommand(ctx context.Context, devContainer *devcontainer.De
 		return nil
 	}
 
-	fmt.Printf("Running postCreateCommand: %s\n", strings.Join(postCreateArgs, " "))
+	debugf("Running postCreateCommand: %s\n", strings.Join(postCreateArgs, " "))
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -285,7 +285,7 @@ func executePostCreateCommand(ctx context.Context, devContainer *devcontainer.De
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -293,7 +293,7 @@ func executePostCreateCommand(ctx context.Context, devContainer *devcontainer.De
 		return err
 	}
 
-	fmt.Println("Finished postCreateCommand")
+	debugln("Finished postCreateCommand")
 	return nil
 }
 
@@ -303,7 +303,7 @@ func executePostStartCommand(ctx context.Context, devContainer *devcontainer.Dev
 		return nil
 	}
 
-	fmt.Printf("Running postStartCommand: %s\n", strings.Join(postStartArgs, " "))
+	debugf("Running postStartCommand: %s\n", strings.Join(postStartArgs, " "))
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -311,7 +311,7 @@ func executePostStartCommand(ctx context.Context, devContainer *devcontainer.Dev
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -319,7 +319,7 @@ func executePostStartCommand(ctx context.Context, devContainer *devcontainer.Dev
 		return err
 	}
 
-	fmt.Println("Finished postStartCommand")
+	debugln("Finished postStartCommand")
 	return nil
 }
 
@@ -329,7 +329,7 @@ func executePostAttachCommand(ctx context.Context, devContainer *devcontainer.De
 		return nil
 	}
 
-	fmt.Printf("Running postAttachCommand: %s\n", strings.Join(postAttachArgs, " "))
+	debugf("Running postAttachCommand: %s\n", strings.Join(postAttachArgs, " "))
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -337,7 +337,7 @@ func executePostAttachCommand(ctx context.Context, devContainer *devcontainer.De
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -345,7 +345,7 @@ func executePostAttachCommand(ctx context.Context, devContainer *devcontainer.De
 		return err
 	}
 
-	fmt.Println("Finished postAttachCommand")
+	debugln("Finished postAttachCommand")
 	return nil
 }
 
@@ -355,7 +355,7 @@ func executeInitializeCommand(devContainer *devcontainer.DevContainer, workspace
 		return nil
 	}
 
-	fmt.Printf("Running initializeCommand: %s\n", strings.Join(initArgs, " "))
+	debugf("Running initializeCommand: %s\n", strings.Join(initArgs, " "))
 
 	cmd := exec.Command(initArgs[0], initArgs[1:]...)
 	cmd.Dir = workspaceDir
@@ -366,7 +366,7 @@ func executeInitializeCommand(devContainer *devcontainer.DevContainer, workspace
 		return fmt.Errorf("initializeCommand failed: %w", err)
 	}
 
-	fmt.Println("Finished initializeCommand")
+	debugln("Finished initializeCommand")
 
 	return nil
 }
@@ -421,7 +421,7 @@ func (r *realDockerClient) StartExistingContainer(ctx context.Context, container
 	if err != nil {
 		return fmt.Errorf("failed to start existing container: %w", err)
 	}
-	fmt.Printf("Container '%s' started successfully\n", containerName)
+	debugf("Container '%s' started successfully\n", containerName)
 	return nil
 }
 
@@ -463,7 +463,7 @@ func (r *realDockerClient) CreateAndStartContainer(ctx context.Context, args Doc
 				env = append(env, fmt.Sprintf("%s=%s", key, value))
 			}
 
-			fmt.Printf("SSH agent forwarding enabled: %s -> %s\n",
+			debugf("SSH agent forwarding enabled: %s -> %s\n",
 				hostSocket, mount.Target)
 		}
 	}
@@ -491,7 +491,7 @@ func (r *realDockerClient) CreateAndStartContainer(ctx context.Context, args Doc
 		return fmt.Errorf("failed to start container: %w", err)
 	}
 
-	fmt.Printf("Container '%s' started successfully\n", args.Name)
+	debugf("Container '%s' started successfully\n", args.Name)
 	return nil
 }
 
@@ -518,7 +518,7 @@ func (r *realDockerClient) PullImage(ctx context.Context, imageName string) erro
 	}
 	defer func() {
 		if closeErr := resp.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close pull response: %v\n", closeErr)
+			warnf("failed to close pull response: %v", closeErr)
 		}
 	}()
 
@@ -528,7 +528,7 @@ func (r *realDockerClient) PullImage(ctx context.Context, imageName string) erro
 		return fmt.Errorf("failed to read pull response: %w", err)
 	}
 
-	fmt.Printf("Image '%s' pulled successfully\n", imageName)
+	debugf("Image '%s' pulled successfully\n", imageName)
 	return nil
 }
 
@@ -561,7 +561,7 @@ func updateRemoteUserUID(ctx context.Context, devContainer *devcontainer.DevCont
 	hostUID := os.Getuid()
 	hostGID := os.Getgid()
 
-	fmt.Printf("Updating container user '%s' UID/GID to match host (%d:%d)\n", targetUser, hostUID, hostGID)
+	debugf("Updating container user '%s' UID/GID to match host (%d:%d)\n", targetUser, hostUID, hostGID)
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -601,7 +601,7 @@ func executeLifecycleCommands(ctx context.Context, devContainer *devcontainer.De
 	// Update remote user UID/GID before executing lifecycle commands
 	if err := updateRemoteUserUID(ctx, devContainer, containerName); err != nil {
 		// Only warn, don't fail the entire lifecycle
-		fmt.Printf("Warning: failed to update remote user UID/GID: %v\n", err)
+		warnf("failed to update remote user UID/GID: %v", err)
 	}
 
 	commands := []struct {
@@ -615,7 +615,7 @@ func executeLifecycleCommands(ctx context.Context, devContainer *devcontainer.De
 	}
 
 	waitFor := devContainer.GetWaitFor()
-	fmt.Printf("Executing lifecycle commands up to: %s\n", waitFor)
+	debugf("Executing lifecycle commands up to: %s\n", waitFor)
 
 	// Execute commands synchronously until waitFor
 	for _, cmd := range commands {
@@ -626,7 +626,7 @@ func executeLifecycleCommands(ctx context.Context, devContainer *devcontainer.De
 		}
 	}
 
-	fmt.Printf("Container is ready for use (waitFor: %s completed)\n", waitFor)
+	debugf("Container is ready for use (waitFor: %s completed)\n", waitFor)
 
 	// Execute remaining commands asynchronously
 	var wg sync.WaitGroup
@@ -636,14 +636,14 @@ func executeLifecycleCommands(ctx context.Context, devContainer *devcontainer.De
 		for _, cmd := range commands {
 			if !devContainer.ShouldWaitForCommand(cmd.commandType) {
 				if err := cmd.executor(ctx, devContainer, containerName, workspaceDir); err != nil {
-					fmt.Printf("Background command %s failed: %v\n", cmd.commandType, err)
+					warnf("background command %s failed: %v", cmd.commandType, err)
 				}
 			}
 		}
 
 		// Always execute postAttachCommand last
 		if err := executePostAttachCommand(ctx, devContainer, containerName, workspaceDir); err != nil {
-			fmt.Printf("Background postAttachCommand failed: %v\n", err)
+			warnf("background postAttachCommand failed: %v", err)
 		}
 	}()
 
@@ -680,6 +680,7 @@ func applyDotfiles(ctx context.Context, devContainer *devcontainer.DevContainer,
 	if cfg == nil {
 		return nil
 	}
+	cfg.Logger = debugf
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -701,7 +702,7 @@ func applyDotfiles(ctx context.Context, devContainer *devcontainer.DevContainer,
 
 	executor := newDotfilesExecutor(cli, containerID)
 	user := devContainer.GetTargetUser()
-	fmt.Printf("Checking dotfiles for container %s as user %s\n", containerName, user)
+	debugf("Checking dotfiles for container %s as user %s\n", containerName, user)
 	return dotfiles.Apply(ctx, executor, user, cfg, forceDotfiles)
 }
 
@@ -726,7 +727,7 @@ func startContainerWithDockerCompose(ctx context.Context, devContainer *devconta
 		// Get base environment variables for expansion
 		baseEnv, err := getComposeServiceEnv(workspaceDir, composeFiles, devContainer.GetService())
 		if err != nil {
-			fmt.Printf("Warning: failed to get base environment variables for compose service: %v\n", err)
+			warnf("failed to get base environment variables for compose service: %v", err)
 			baseEnv = make(map[string]string)
 		}
 
@@ -738,7 +739,7 @@ func startContainerWithDockerCompose(ctx context.Context, devContainer *devconta
 		if overrideFile != "" {
 			defer func() {
 				if err := os.Remove(overrideFile); err != nil {
-					fmt.Printf("Warning: failed to remove temporary override file: %v\n", err)
+					warnf("failed to remove temporary override file: %v", err)
 				}
 			}()
 			composeArgs = append(composeArgs, "-f", overrideFile)
@@ -758,12 +759,12 @@ func startContainerWithDockerCompose(ctx context.Context, devContainer *devconta
 	upCmd.Stdout = os.Stdout
 	upCmd.Stderr = os.Stderr
 
-	fmt.Printf("Starting docker compose services: %s\n", strings.Join(runServices, ", "))
+	debugf("Starting docker compose services: %s\n", strings.Join(runServices, ", "))
 	if err := upCmd.Run(); err != nil {
 		return fmt.Errorf("failed to start docker compose services: %w", err)
 	}
 
-	fmt.Printf("Docker compose services started successfully\n")
+	debugf("Docker compose services started successfully\n")
 	return executeLifecycleCommands(ctx, devContainer, containerName, workspaceDir)
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -680,7 +680,6 @@ func applyDotfiles(ctx context.Context, devContainer *devcontainer.DevContainer,
 	if cfg == nil {
 		return nil
 	}
-	cfg.Logger = debugf
 
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -703,7 +702,7 @@ func applyDotfiles(ctx context.Context, devContainer *devcontainer.DevContainer,
 	executor := newDotfilesExecutor(cli, containerID)
 	user := devContainer.GetTargetUser()
 	debugf("Checking dotfiles for container %s as user %s\n", containerName, user)
-	return dotfiles.Apply(ctx, executor, user, cfg, forceDotfiles)
+	return dotfiles.Apply(ctx, executor, user, cfg, forceDotfiles, debugf)
 }
 
 func startContainerWithDockerCompose(ctx context.Context, devContainer *devcontainer.DevContainer, containerName, workspaceDir string) error {

--- a/cmd/user_commands.go
+++ b/cmd/user_commands.go
@@ -50,7 +50,7 @@ func findRunningDevContainer(ctx context.Context, devContainer *devcontainer.Dev
 	}
 	defer func() {
 		if closeErr := cli.Close(); closeErr != nil {
-			fmt.Printf("Warning: failed to close Docker client: %v\n", closeErr)
+			warnf("failed to close Docker client: %v", closeErr)
 		}
 	}()
 
@@ -117,6 +117,6 @@ func runLifecycleCommands(ctx context.Context, devContainer *devcontainer.DevCon
 		return fmt.Errorf("postAttachCommand failed: %w", err)
 	}
 
-	fmt.Printf("Successfully executed user commands up to %s\n", waitFor)
+	debugf("Successfully executed user commands up to %s\n", waitFor)
 	return nil
 }

--- a/pkg/dotfiles/dotfiles.go
+++ b/pkg/dotfiles/dotfiles.go
@@ -41,20 +41,20 @@ type Config struct {
 	Repository     string
 	TargetPath     string
 	InstallCommand string
-	// Logger receives informational progress messages (clone start,
-	// install completion, "already present" skips). It is invoked exactly
-	// like fmt.Printf — no trailing newline is added. When nil, dotfiles
-	// processing stays silent; the cmd layer wires this to a --debug-gated
-	// logger so the noisy default `devgo up` output goes away.
-	Logger func(format string, args ...any)
 }
 
-func (c *Config) logf(format string, args ...any) {
-	if c == nil || c.Logger == nil {
-		return
-	}
-	c.Logger(format, args...)
-}
+// Logf is the progress-logging callback Apply uses for informational
+// messages (clone start, install completion, "already present" skips). It
+// is invoked exactly like fmt.Printf — no trailing newline is added. The
+// cmd layer passes a --debug-gated function so the noisy default `devgo
+// up` output goes away; pass nil (or [Discard]) to silence dotfiles
+// progress entirely.
+type Logf func(format string, args ...any)
+
+// Discard is a no-op [Logf]. Callers that do not need progress output (or
+// tests that want silent runs) pass it to Apply so the body can call the
+// logger unconditionally without nil checks.
+func Discard(string, ...any) {}
 
 // Override holds CLI-supplied values. Empty fields fall back to the user
 // config file. Strings are used (not pointers) since dotfiles values are all
@@ -119,12 +119,18 @@ func Resolve(fileCfg *config.DotfilesConfig, override Override, disabled bool) *
 //   - When InstallCommand is empty, devgo probes DefaultInstallScripts in
 //     order and runs the first match. If none match, the clone is left in
 //     place (clone-only mode).
-func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force bool) error {
+//
+// logf receives human-readable progress messages. Pass [Discard] to suppress
+// them; a nil callback is treated the same way.
+func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force bool, logf Logf) error {
 	if cfg == nil {
 		return nil
 	}
 	if cfg.Repository == "" {
 		return fmt.Errorf("dotfiles repository is empty")
+	}
+	if logf == nil {
+		logf = Discard
 	}
 
 	target, err := resolveHome(ctx, exec, user, cfg.TargetPath)
@@ -139,7 +145,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 
 	if exists {
 		if !force {
-			cfg.logf("dotfiles target %s already exists, skipping (use --force-dotfiles to overwrite)\n", target)
+			logf("dotfiles target %s already exists, skipping (use --force-dotfiles to overwrite)\n", target)
 			return nil
 		}
 		if err := removePath(ctx, exec, user, target); err != nil {
@@ -147,7 +153,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 		}
 	}
 
-	cfg.logf("Applying dotfiles from %s into %s\n", SanitizeRepoURL(cfg.Repository), target)
+	logf("Applying dotfiles from %s into %s\n", SanitizeRepoURL(cfg.Repository), target)
 	if err := cloneRepo(ctx, exec, user, cfg.Repository, target); err != nil {
 		return fmt.Errorf("failed to clone dotfiles: %w", err)
 	}
@@ -157,7 +163,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 		return fmt.Errorf("failed to resolve install script: %w", err)
 	}
 	if script == "" {
-		cfg.logf("dotfiles cloned; no install script found, skipping install step\n")
+		logf("dotfiles cloned; no install script found, skipping install step\n")
 		return nil
 	}
 
@@ -165,7 +171,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 		return fmt.Errorf("install script %s failed: %w", script, err)
 	}
 
-	cfg.logf("dotfiles installed from %s\n", SanitizeRepoURL(cfg.Repository))
+	logf("dotfiles installed from %s\n", SanitizeRepoURL(cfg.Repository))
 	return nil
 }
 

--- a/pkg/dotfiles/dotfiles.go
+++ b/pkg/dotfiles/dotfiles.go
@@ -41,6 +41,19 @@ type Config struct {
 	Repository     string
 	TargetPath     string
 	InstallCommand string
+	// Logger receives informational progress messages (clone start,
+	// install completion, "already present" skips). It is invoked exactly
+	// like fmt.Printf — no trailing newline is added. When nil, dotfiles
+	// processing stays silent; the cmd layer wires this to a --debug-gated
+	// logger so the noisy default `devgo up` output goes away.
+	Logger func(format string, args ...any)
+}
+
+func (c *Config) logf(format string, args ...any) {
+	if c == nil || c.Logger == nil {
+		return
+	}
+	c.Logger(format, args...)
 }
 
 // Override holds CLI-supplied values. Empty fields fall back to the user
@@ -126,7 +139,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 
 	if exists {
 		if !force {
-			fmt.Printf("dotfiles target %s already exists, skipping (use --force-dotfiles to overwrite)\n", target)
+			cfg.logf("dotfiles target %s already exists, skipping (use --force-dotfiles to overwrite)\n", target)
 			return nil
 		}
 		if err := removePath(ctx, exec, user, target); err != nil {
@@ -134,7 +147,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 		}
 	}
 
-	fmt.Printf("Applying dotfiles from %s into %s\n", SanitizeRepoURL(cfg.Repository), target)
+	cfg.logf("Applying dotfiles from %s into %s\n", SanitizeRepoURL(cfg.Repository), target)
 	if err := cloneRepo(ctx, exec, user, cfg.Repository, target); err != nil {
 		return fmt.Errorf("failed to clone dotfiles: %w", err)
 	}
@@ -144,7 +157,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 		return fmt.Errorf("failed to resolve install script: %w", err)
 	}
 	if script == "" {
-		fmt.Println("dotfiles cloned; no install script found, skipping install step")
+		cfg.logf("dotfiles cloned; no install script found, skipping install step\n")
 		return nil
 	}
 
@@ -152,7 +165,7 @@ func Apply(ctx context.Context, exec Executor, user string, cfg *Config, force b
 		return fmt.Errorf("install script %s failed: %w", script, err)
 	}
 
-	fmt.Printf("dotfiles installed from %s\n", SanitizeRepoURL(cfg.Repository))
+	cfg.logf("dotfiles installed from %s\n", SanitizeRepoURL(cfg.Repository))
 	return nil
 }
 

--- a/pkg/dotfiles/dotfiles_test.go
+++ b/pkg/dotfiles/dotfiles_test.go
@@ -123,7 +123,7 @@ func (f *fakeExec) commandsContaining(substr string) int {
 
 func TestApply_NilConfig_NoOp(t *testing.T) {
 	exec := &fakeExec{}
-	if err := Apply(context.Background(), exec, "user", nil, false); err != nil {
+	if err := Apply(context.Background(), exec, "user", nil, false, nil); err != nil {
 		t.Errorf("Apply(nil) error = %v, want nil", err)
 	}
 	if len(exec.calls) != 0 {
@@ -138,7 +138,7 @@ func TestApply_SkipsWhenTargetExistsAndNotForce(t *testing.T) {
 		},
 	}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "/home/u/df"}
-	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+	if err := Apply(context.Background(), exec, "u", cfg, false, nil); err != nil {
 		t.Fatalf("Apply error = %v", err)
 	}
 	if exec.commandsContaining("git clone") != 0 {
@@ -156,7 +156,7 @@ func TestApply_ForceRemovesAndReclones(t *testing.T) {
 		},
 	}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "/home/u/df"}
-	if err := Apply(context.Background(), exec, "u", cfg, true); err != nil {
+	if err := Apply(context.Background(), exec, "u", cfg, true, nil); err != nil {
 		t.Fatalf("Apply error = %v", err)
 	}
 	if exec.commandsContaining("rm -rf") != 1 {
@@ -180,7 +180,7 @@ func TestApply_RunsExplicitInstallCommand(t *testing.T) {
 		TargetPath:     "~/df",
 		InstallCommand: "bootstrap.sh",
 	}
-	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+	if err := Apply(context.Background(), exec, "u", cfg, false, nil); err != nil {
 		t.Fatalf("Apply error = %v", err)
 	}
 	if exec.commandsContaining("./bootstrap.sh") != 1 {
@@ -203,7 +203,7 @@ func TestApply_FailsWhenExplicitInstallCommandMissing(t *testing.T) {
 		TargetPath:     "~/df",
 		InstallCommand: "missing.sh",
 	}
-	err := Apply(context.Background(), exec, "u", cfg, false)
+	err := Apply(context.Background(), exec, "u", cfg, false, nil)
 	if err == nil {
 		t.Fatalf("expected Apply to error when explicit install command is missing")
 	}
@@ -224,7 +224,7 @@ func TestApply_DetectsDefaultInstallScript(t *testing.T) {
 		{contains: "[ -e", exitCode: 1}, // target path probe and any others
 	}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
-	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+	if err := Apply(context.Background(), exec, "u", cfg, false, nil); err != nil {
 		t.Fatalf("Apply error = %v", err)
 	}
 	if exec.commandsContaining("./bootstrap.sh") != 1 {
@@ -309,7 +309,7 @@ func TestResolveHome_RejectsOtherUserForm(t *testing.T) {
 
 func TestApply_RejectsOtherUserPath(t *testing.T) {
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~someone/df"}
-	err := Apply(context.Background(), &fakeExec{}, "u", cfg, false)
+	err := Apply(context.Background(), &fakeExec{}, "u", cfg, false, nil)
 	if err == nil {
 		t.Fatalf("expected wrapped ~user error from Apply, got nil")
 	}
@@ -326,7 +326,7 @@ func TestApply_PropagatesInstallScriptFailure(t *testing.T) {
 		{contains: "&& './install.sh'", stdout: "starting", stderr: "boom", exitCode: 2},
 	}}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
-	err := Apply(context.Background(), exec, "u", cfg, false)
+	err := Apply(context.Background(), exec, "u", cfg, false, nil)
 	if err == nil {
 		t.Fatalf("expected install script error, got nil")
 	}
@@ -346,7 +346,7 @@ func TestApply_InstallScriptExit126_AddsExecutableHint(t *testing.T) {
 		{contains: "&& './install.sh'", stderr: "Permission denied", exitCode: 126},
 	}}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
-	err := Apply(context.Background(), exec, "u", cfg, false)
+	err := Apply(context.Background(), exec, "u", cfg, false, nil)
 	if err == nil {
 		t.Fatalf("expected error for exit 126, got nil")
 	}
@@ -374,7 +374,7 @@ func TestApply_NeverPassesUnresolvedTilde(t *testing.T) {
 		},
 	}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/dotfiles"}
-	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+	if err := Apply(context.Background(), exec, "u", cfg, false, nil); err != nil {
 		t.Fatalf("Apply error = %v", err)
 	}
 	for i, c := range exec.calls {
@@ -403,7 +403,7 @@ func TestApply_DefaultConfig_DoesNotCloneIntoBareHome(t *testing.T) {
 	if resolved == nil {
 		t.Fatalf("Resolve returned nil")
 	}
-	if err := Apply(context.Background(), exec, "u", resolved, false); err != nil {
+	if err := Apply(context.Background(), exec, "u", resolved, false, nil); err != nil {
 		t.Fatalf("Apply error = %v", err)
 	}
 	if exec.commandsContaining("git clone") == 0 {
@@ -431,7 +431,7 @@ func TestApply_NoInstallScriptFound_LeavesCloneInPlace(t *testing.T) {
 		},
 	}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "/home/u/df"}
-	if err := Apply(context.Background(), exec, "u", cfg, false); err != nil {
+	if err := Apply(context.Background(), exec, "u", cfg, false, nil); err != nil {
 		t.Fatalf("Apply error = %v", err)
 	}
 	if exec.commandsContaining("git clone") != 1 {

--- a/test/integration/up_test.go
+++ b/test/integration/up_test.go
@@ -449,11 +449,13 @@ func TestOnCreateCommandIntegration(t *testing.T) {
 				t.Fatalf("Failed to change to working directory: %v", err)
 			}
 
-			// Run devgo up command
+			// Run devgo up command. --debug is required so the lifecycle
+			// progress messages we assert on below are emitted; without it
+			// devgo stays quiet by design.
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
 
-			cmd := exec.CommandContext(ctx, devgoBinary, "up")
+			cmd := exec.CommandContext(ctx, devgoBinary, "--debug", "up")
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("devgo up failed: %v. Output: %s", err, string(output))
@@ -540,11 +542,13 @@ func TestOnCreateCommandFailure(t *testing.T) {
 		t.Fatalf("Failed to change to working directory: %v", err)
 	}
 
-	// Run devgo up command - should execute onCreateCommand but continue even if it fails
+	// Run devgo up command - should execute onCreateCommand but continue
+	// even if it fails. --debug is required so the lifecycle progress
+	// messages we assert on below are emitted.
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, devgoBinary, "up")
+	cmd := exec.CommandContext(ctx, devgoBinary, "--debug", "up")
 	output, err := cmd.CombinedOutput()
 
 	// Current implementation continues even if onCreateCommand fails
@@ -758,11 +762,12 @@ func TestUpdateRemoteUserUIDIntegration(t *testing.T) {
 				t.Fatalf("Failed to change to working directory: %v", err)
 			}
 
-			// Run devgo up command
+			// Run devgo up command. --debug is required so the UID/GID
+			// progress message we look for below is emitted.
 			ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 			defer cancel()
 
-			cmd := exec.CommandContext(ctx, devgoBinary, "up")
+			cmd := exec.CommandContext(ctx, devgoBinary, "--debug", "up")
 			output, err := cmd.CombinedOutput()
 			if err != nil {
 				t.Fatalf("devgo up failed: %v. Output: %s", err, string(output))


### PR DESCRIPTION
## Output noise on every `devgo up`

Running `devgo up` printed every container lifecycle step, image pull, SSH agent
forwarding mount, postCreateCommand boundary, and dotfiles event to stdout.
The progress chatter drowned out the user's own postCreateCommand output and
made even `./devgo` (no args) emit three lines of internal state. The user
filed this as too noisy and asked for the messages to be hidden behind a
debug toggle.

## Introduce `--debug` and route progress through stderr helpers

- Rename the existing `verbose` global to `debug`, expose it as `--debug`,
  keep `--verbose` as a deprecated alias so existing scripts keep working.
- Add `debugf` / `debugln` helpers in `cmd/root.go` that write to stderr only
  when `--debug` is on, and route every container lifecycle / build / dotfiles
  status message through them.
- Replace inline `fmt.Printf("Warning: ...")` calls with the existing `warnf`
  helper so warnings always land on stderr regardless of debug state.

## Keep `pkg/dotfiles` free of fmt.Print and the awkward `cfg.Logger`

The first pass added a `Logger` field on `dotfiles.Config`, which mixed
configuration data with behavior. The follow-up commit drops the field and
takes the callback as a dedicated `Logf` parameter on `Apply`, with a
`Discard` helper for silent callers. `cmd/up` threads its `--debug`-gated
`debugf` directly into the call.

## Test plan

- [x] `make build`
- [x] `make test` (cmd, config, devcontainer, dotfiles, sshagent — all pass)
- [x] `make lint` (0 issues)
- [x] `./devgo` and `./devgo --help` produce no progress chatter; `./devgo --debug`
  and `./devgo --verbose` both still emit the lookup trace.

Generated with [Claude Code](https://claude.com/claude-code)