### PR TITLE
Parse devcontainer features field

### DIFF
--- a/pkg/devcontainer/devcontainer.go
+++ b/pkg/devcontainer/devcontainer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 
 	"github.com/titanous/json5"
 )
@@ -61,6 +62,20 @@ type DevContainer struct {
 	PostStartCommand     interface{}               `json:"postStartCommand,omitempty"`
 	PostAttachCommand    interface{}               `json:"postAttachCommand,omitempty"`
 	WaitFor              string                    `json:"waitFor,omitempty"`
+	// Features maps a feature reference (e.g. "ghcr.io/devcontainers/features/node:1")
+	// to its options. The options value may be an object, a bare scalar, or empty.
+	Features map[string]interface{} `json:"features,omitempty"`
+	// OverrideFeatureInstallOrder is parsed but currently ignored (install order is
+	// derived from the sorted feature references).
+	OverrideFeatureInstallOrder []string `json:"overrideFeatureInstallOrder,omitempty"`
+}
+
+// FeatureSpec is a single feature declaration resolved from the features map.
+type FeatureSpec struct {
+	// Ref is the OCI reference of the feature.
+	Ref string
+	// Options holds the user-provided options for the feature.
+	Options map[string]interface{}
 }
 
 func Parse(filePath string) (*DevContainer, error) {
@@ -254,6 +269,46 @@ func (dc *DevContainer) ShouldWaitForCommand(commandType string) bool {
 	default:
 		return false
 	}
+}
+
+// HasFeatures reports whether any devcontainer features are declared.
+func (dc *DevContainer) HasFeatures() bool {
+	return len(dc.Features) > 0
+}
+
+// GetFeatures returns the declared features as a slice of FeatureSpec.
+// Because Go maps are unordered, the features are returned sorted by reference
+// for reproducible install order (MVP: overrideFeatureInstallOrder and
+// installsAfter are not yet honored).
+func (dc *DevContainer) GetFeatures() []FeatureSpec {
+	if len(dc.Features) == 0 {
+		return nil
+	}
+
+	refs := make([]string, 0, len(dc.Features))
+	for ref := range dc.Features {
+		refs = append(refs, ref)
+	}
+	sort.Strings(refs)
+
+	specs := make([]FeatureSpec, 0, len(refs))
+	for _, ref := range refs {
+		specs = append(specs, FeatureSpec{
+			Ref:     ref,
+			Options: normalizeFeatureOptions(dc.Features[ref]),
+		})
+	}
+	return specs
+}
+
+// normalizeFeatureOptions converts the raw options value into a map.
+// Object values are returned as-is; any other form (bare scalar, bool, or
+// empty) yields an empty map so that feature defaults apply.
+func normalizeFeatureOptions(raw interface{}) map[string]interface{} {
+	if m, ok := raw.(map[string]interface{}); ok {
+		return m
+	}
+	return map[string]interface{}{}
 }
 
 func (dc *DevContainer) HasDockerCompose() bool {

--- a/pkg/devcontainer/devcontainer_test.go
+++ b/pkg/devcontainer/devcontainer_test.go
@@ -1706,3 +1706,80 @@ func TestHasBuild_WithLegacyDockerfile(t *testing.T) {
 		})
 	}
 }
+
+func TestParse_Features(t *testing.T) {
+	fixturePath := filepath.Join("..", "..", "test", "fixtures", "features.json")
+
+	dc, err := Parse(fixturePath)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	if !dc.HasFeatures() {
+		t.Fatal("HasFeatures() = false, want true")
+	}
+
+	if len(dc.Features) != 3 {
+		t.Errorf("Features length = %d, want 3", len(dc.Features))
+	}
+
+	if len(dc.OverrideFeatureInstallOrder) != 1 {
+		t.Errorf("OverrideFeatureInstallOrder length = %d, want 1",
+			len(dc.OverrideFeatureInstallOrder))
+	}
+
+	specs := dc.GetFeatures()
+	if len(specs) != 3 {
+		t.Fatalf("GetFeatures() length = %d, want 3", len(specs))
+	}
+
+	// Specs are sorted by reference for reproducibility.
+	if specs[0].Ref != "ghcr.io/devcontainers/features/common-utils:2" {
+		t.Errorf("first spec ref = %q", specs[0].Ref)
+	}
+
+	// Object options are preserved.
+	var nodeSpec *FeatureSpec
+	for i := range specs {
+		if specs[i].Ref == "ghcr.io/devcontainers/features/node:1" {
+			nodeSpec = &specs[i]
+		}
+	}
+	if nodeSpec == nil {
+		t.Fatal("node feature spec not found")
+	}
+	if nodeSpec.Options["version"] != "20" {
+		t.Errorf("node version option = %v, want 20", nodeSpec.Options["version"])
+	}
+
+	// Bare-scalar options normalize to an empty map.
+	for i := range specs {
+		if specs[i].Ref == "ghcr.io/devcontainers/features/git:1" {
+			if len(specs[i].Options) != 0 {
+				t.Errorf("git options = %v, want empty", specs[i].Options)
+			}
+		}
+	}
+}
+
+func TestHasFeatures(t *testing.T) {
+	tests := []struct {
+		name     string
+		dc       DevContainer
+		expected bool
+	}{
+		{name: "no features", dc: DevContainer{}, expected: false},
+		{
+			name:     "with features",
+			dc:       DevContainer{Features: map[string]interface{}{"ghcr.io/x/y:1": map[string]interface{}{}}},
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.dc.HasFeatures(); got != tt.expected {
+				t.Errorf("HasFeatures() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/test/fixtures/features.json
+++ b/test/fixtures/features.json
@@ -1,0 +1,14 @@
+{
+  "name": "Features Dev Container",
+  "image": "ubuntu:22.04",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/git:1": "latest"
+  },
+  "overrideFeatureInstallOrder": [
+    "ghcr.io/devcontainers/features/common-utils:2"
+  ]
+}


### PR DESCRIPTION
## Summary

First of a 3-PR stack adding devcontainer **Features** support. This PR is parsing only — no behavior change.

- Add `features` and `overrideFeatureInstallOrder` fields to the `DevContainer` struct so they are no longer silently dropped during parsing.
- Add `HasFeatures()` / `GetFeatures()` accessors. `GetFeatures()` normalizes per-feature options and returns specs sorted by reference for reproducible ordering.
- Add `test/fixtures/features.json` and parsing tests.

## Stack

1. **This PR** — parse the features field
2. `claude/features-pkg-jwgvb8` — `pkg/features` core library (OCI pull + Dockerfile generation)
3. `claude/features-wiring-jwgvb8` — wire into `up`/`build` + integration test + docs

## Test

`go test ./pkg/devcontainer/...` passes; `go build ./...` clean.

https://claude.ai/code/session_01JPmMkPSLSvRfrNineKTDqs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPmMkPSLSvRfrNineKTDqs)_