### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -239,7 +239,7 @@ Examples:
 }
 
 func showVersionInfo() {
-	fmt.Println("devgo version 0.1.0")
+	fmt.Println("devgo version 0.2.0")
 }
 
 func runDevContainer(args []string) error {


### PR DESCRIPTION
Bump the version string to 0.2.0 for the next release.

## Changes since v0.1.0
- Parse devcontainer `features` field (#65)
- Add dotfiles guidance comment to init template (#68)
- Suppress lifecycle output unless `--debug` is passed (quiet default output) (#64)

🤖 Generated with [Claude Code](https://claude.com/claude-code)