### PR TITLE
Support arguments in dotfiles installCommand

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -221,7 +221,8 @@ Flags:
   --dotfiles-target-path string
         Path inside the container where the dotfiles repo is cloned (default "~/dotfiles")
   --dotfiles-install-command string
-        Install script to run after cloning (relative to target path)
+        Install command to run after cloning; first token is the script path
+        (relative to target path), remaining tokens are passed as arguments
   --no-dotfiles
         Disable dotfiles processing for this invocation
   --force-dotfiles

--- a/docs/dotfiles.md
+++ b/docs/dotfiles.md
@@ -41,7 +41,7 @@ automatically when `devgo up` runs.
 |-----|----------|---------|-------------|
 | `repository` | yes | — | Git URL of the dotfiles repository. Any URL `git clone` accepts (https, ssh, git protocol). |
 | `targetPath` | no | `~/dotfiles` | Directory inside the container where the repository is cloned. A leading `~` or `~/` is expanded to the target user's `$HOME` (resolved inside the container). The target should not be the home directory itself, since `git clone` refuses to write into a non-empty directory. |
-| `installCommand` | no | (auto) | Path of the install script to execute after cloning, relative to `targetPath`. When empty, devgo searches for a known script (see below). |
+| `installCommand` | no | (auto) | Install command to execute after cloning. The first token is the script path (relative to `targetPath`); any remaining tokens are passed to the script as arguments, e.g. `install.sh --tool`. When empty, devgo searches for a known script (see below). |
 
 ### Auto-detected install script
 
@@ -92,9 +92,12 @@ The CLI flags take precedence over `~/.config/devgo/config.json`.
   has the right keys loaded.
 * If `targetPath` already exists, devgo **skips both clone and install** to
   avoid trampling over user changes. Use `--force-dotfiles` to override.
-* The install script runs as a single `sh -c "cd <targetPath> && <script>"`.
-  Both the `cd` and the script execute inside the same shell, so any
-  environment variables exported by the script affect only that shell.
+* The install command runs as a single `sh -c "cd <targetPath> && <installCommand>"`.
+  Both the `cd` and the command execute inside the same shell, so any
+  environment variables exported by the script affect only that shell. The
+  command is not shell-quoted, so arguments in `installCommand` (and other
+  shell syntax) are honored. Because dotfiles repositories are trusted, this
+  is intentional; do not point `installCommand` at untrusted content.
 * The install script must be **executable** (`chmod +x install.sh`) and have
   a shebang the container can resolve. Non-zero exit codes 126 (not
   executable) and 127 (interpreter missing) trigger an explicit hint in the

--- a/pkg/dotfiles/dotfiles.go
+++ b/pkg/dotfiles/dotfiles.go
@@ -282,10 +282,14 @@ func runInstallScript(ctx context.Context, exec Executor, user, targetPath, comm
 	// adjusted with a leading "./" when it is a bare relative name. The line
 	// is intentionally NOT shell-quoted: dotfiles repos are trusted, and
 	// quoting the whole string would collapse arguments into one filename.
-	scriptName := firstToken(command)
-	invocation := command
+	// Trim surrounding whitespace before prepending "./" so a value like
+	// "  install.sh --tool" does not become "./  install.sh --tool" (the "./"
+	// must attach directly to the script name). Internal spacing between
+	// arguments is preserved.
+	invocation := strings.TrimSpace(command)
+	scriptName := firstToken(invocation)
 	if !strings.HasPrefix(scriptName, "/") && !strings.HasPrefix(scriptName, "./") {
-		invocation = "./" + command
+		invocation = "./" + invocation
 	}
 	cmd := []string{"sh", "-c", fmt.Sprintf("cd %s && %s", shellQuote(targetPath), invocation)}
 	stdout, stderr, exitCode, err := exec.Exec(ctx, user, cmd)

--- a/pkg/dotfiles/dotfiles.go
+++ b/pkg/dotfiles/dotfiles.go
@@ -243,19 +243,22 @@ func cloneRepo(ctx context.Context, exec Executor, user, repo, target string) er
 
 func resolveInstallScript(ctx context.Context, exec Executor, user, targetPath, explicit string) (string, error) {
 	if explicit != "" {
-		// When the user pinned a script name, surface a clear "missing"
-		// error rather than letting the eventual `sh -c './script'` fail
-		// with exit 127 mixed into other install error paths.
-		probe := explicit
+		// installCommand may carry arguments (e.g. "install.sh --tool"), so
+		// only the first token is the script path; the rest are passed
+		// through to the script verbatim. Probe just the script's existence
+		// to surface a clear "missing" error rather than letting the eventual
+		// `sh -c './script ...'` fail with exit 127 mixed into other paths.
+		scriptName := firstToken(explicit)
+		probe := scriptName
 		if !strings.HasPrefix(probe, "/") {
-			probe = path.Join(targetPath, strings.TrimPrefix(explicit, "./"))
+			probe = path.Join(targetPath, strings.TrimPrefix(scriptName, "./"))
 		}
 		exists, err := pathExists(ctx, exec, user, probe)
 		if err != nil {
 			return "", err
 		}
 		if !exists {
-			return "", fmt.Errorf("configured installCommand %q does not exist in dotfiles repo at %s", explicit, targetPath)
+			return "", fmt.Errorf("configured installCommand %q does not exist in dotfiles repo at %s", scriptName, targetPath)
 		}
 		return explicit, nil
 	}
@@ -272,16 +275,19 @@ func resolveInstallScript(ctx context.Context, exec Executor, user, targetPath, 
 	return "", nil
 }
 
-func runInstallScript(ctx context.Context, exec Executor, user, targetPath, script string) error {
-	invocation := script
-	if !strings.HasPrefix(script, "/") && !strings.HasPrefix(script, "./") {
-		invocation = "./" + script
+func runInstallScript(ctx context.Context, exec Executor, user, targetPath, command string) error {
+	// command is the resolved installCommand, which may include arguments
+	// (e.g. "install.sh --tool"). It is run as a shell command line so the
+	// arguments reach the script. Only the first token (the script path) is
+	// adjusted with a leading "./" when it is a bare relative name. The line
+	// is intentionally NOT shell-quoted: dotfiles repos are trusted, and
+	// quoting the whole string would collapse arguments into one filename.
+	scriptName := firstToken(command)
+	invocation := command
+	if !strings.HasPrefix(scriptName, "/") && !strings.HasPrefix(scriptName, "./") {
+		invocation = "./" + command
 	}
-	// Quote the script path so a value like "install.sh; rm -rf ~" is treated
-	// as a single filename argument rather than a shell command sequence.
-	// Anything more elaborate (shell pipelines, args) belongs inside the
-	// dotfiles repo's own install script.
-	cmd := []string{"sh", "-c", fmt.Sprintf("cd %s && %s", shellQuote(targetPath), shellQuote(invocation))}
+	cmd := []string{"sh", "-c", fmt.Sprintf("cd %s && %s", shellQuote(targetPath), invocation)}
 	stdout, stderr, exitCode, err := exec.Exec(ctx, user, cmd)
 	if err != nil {
 		return err
@@ -306,6 +312,17 @@ func runInstallScript(ctx context.Context, exec Executor, user, targetPath, scri
 // password (if present) is also stripped along with the username.
 func SanitizeRepoURL(repo string) string {
 	return credentialURLPattern.ReplaceAllString(repo, "${1}***@")
+}
+
+// firstToken returns the first whitespace-separated field of s, which for an
+// installCommand is the script path (the remainder being its arguments). It
+// returns the empty string when s is blank or whitespace-only.
+func firstToken(s string) string {
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[0]
 }
 
 // shellQuote wraps a value in single quotes for safe inclusion in `sh -c`.

--- a/pkg/dotfiles/dotfiles_test.go
+++ b/pkg/dotfiles/dotfiles_test.go
@@ -239,6 +239,33 @@ func TestApply_RunsExplicitInstallCommandWithArgs(t *testing.T) {
 	}
 }
 
+func TestApply_RunsExplicitInstallCommandWithLeadingWhitespace(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+			{contains: "[ -e '/home/u/df/install.sh'", exitCode: 0},
+			{contains: "[ -e", exitCode: 1},
+		},
+	}
+	cfg := &Config{
+		Repository:     "https://example.com/x",
+		TargetPath:     "~/df",
+		InstallCommand: "  install.sh --tool",
+	}
+	if err := Apply(context.Background(), exec, "u", cfg, false, nil); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("./install.sh --tool") != 1 {
+		t.Errorf("expected leading whitespace to be trimmed before ./ prefix, got calls=%v", exec.calls)
+	}
+	for _, c := range exec.calls {
+		joined := strings.Join(c.cmd, " ")
+		if strings.Contains(joined, "./  install.sh") {
+			t.Errorf("leading whitespace must not separate ./ from the script name: %v", c.cmd)
+		}
+	}
+}
+
 func TestApply_FailsWhenExplicitInstallCommandWithArgsScriptMissing(t *testing.T) {
 	exec := &fakeExec{
 		rules: []fakeRule{
@@ -257,6 +284,9 @@ func TestApply_FailsWhenExplicitInstallCommandWithArgsScriptMissing(t *testing.T
 	}
 	if !strings.Contains(err.Error(), "missing.sh") {
 		t.Errorf("error %q should mention the missing script name", err.Error())
+	}
+	if exec.commandsContaining("./missing.sh") != 0 {
+		t.Errorf("install command must not run when the script is missing (probe before run), got calls=%v", exec.calls)
 	}
 }
 

--- a/pkg/dotfiles/dotfiles_test.go
+++ b/pkg/dotfiles/dotfiles_test.go
@@ -212,6 +212,54 @@ func TestApply_FailsWhenExplicitInstallCommandMissing(t *testing.T) {
 	}
 }
 
+func TestApply_RunsExplicitInstallCommandWithArgs(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+			{contains: "[ -e '/home/u/df/install.sh'", exitCode: 0}, // first-token probe exists
+			{contains: "[ -e", exitCode: 1},                         // target dir probe missing
+		},
+	}
+	cfg := &Config{
+		Repository:     "https://example.com/x",
+		TargetPath:     "~/df",
+		InstallCommand: "install.sh --tool",
+	}
+	if err := Apply(context.Background(), exec, "u", cfg, false, nil); err != nil {
+		t.Fatalf("Apply error = %v", err)
+	}
+	if exec.commandsContaining("./install.sh --tool") != 1 {
+		t.Errorf("expected install command with args to run, got calls=%v", exec.calls)
+	}
+	for _, c := range exec.calls {
+		joined := strings.Join(c.cmd, " ")
+		if strings.Contains(joined, "'./install.sh --tool'") {
+			t.Errorf("install command must not be shell-quoted as a single token: %v", c.cmd)
+		}
+	}
+}
+
+func TestApply_FailsWhenExplicitInstallCommandWithArgsScriptMissing(t *testing.T) {
+	exec := &fakeExec{
+		rules: []fakeRule{
+			{contains: `printf %s "$HOME"`, stdout: "/home/u"},
+			{contains: "[ -e", exitCode: 1}, // first-token probe and target probe miss
+		},
+	}
+	cfg := &Config{
+		Repository:     "https://example.com/x",
+		TargetPath:     "~/df",
+		InstallCommand: "missing.sh --tool",
+	}
+	err := Apply(context.Background(), exec, "u", cfg, false, nil)
+	if err == nil {
+		t.Fatalf("expected Apply to error when install script is missing")
+	}
+	if !strings.Contains(err.Error(), "missing.sh") {
+		t.Errorf("error %q should mention the missing script name", err.Error())
+	}
+}
+
 func TestApply_DetectsDefaultInstallScript(t *testing.T) {
 	// Simulate that target doesn't exist initially, then clone happens, then
 	// install.sh is missing but bootstrap.sh exists.
@@ -323,7 +371,7 @@ func TestApply_PropagatesInstallScriptFailure(t *testing.T) {
 		{contains: `printf %s "$HOME"`, stdout: "/home/u"},
 		{contains: "[ -e '/home/u/df/install.sh'", exitCode: 0},
 		{contains: "[ -e", exitCode: 1},
-		{contains: "&& './install.sh'", stdout: "starting", stderr: "boom", exitCode: 2},
+		{contains: "&& ./install.sh", stdout: "starting", stderr: "boom", exitCode: 2},
 	}}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
 	err := Apply(context.Background(), exec, "u", cfg, false, nil)
@@ -343,7 +391,7 @@ func TestApply_InstallScriptExit126_AddsExecutableHint(t *testing.T) {
 		{contains: `printf %s "$HOME"`, stdout: "/home/u"},
 		{contains: "[ -e '/home/u/df/install.sh'", exitCode: 0},
 		{contains: "[ -e", exitCode: 1},
-		{contains: "&& './install.sh'", stderr: "Permission denied", exitCode: 126},
+		{contains: "&& ./install.sh", stderr: "Permission denied", exitCode: 126},
 	}}
 	cfg := &Config{Repository: "https://example.com/x", TargetPath: "~/df"}
 	err := Apply(context.Background(), exec, "u", cfg, false, nil)


### PR DESCRIPTION
## Pass arguments to the dotfiles install script

The dotfiles `installCommand` was shell-quoted as a single token, so a value
like `install.sh --tool` was treated as one filename. It failed both the
existence probe (`configured installCommand ... does not exist`) and execution.
The only workaround was to wrap the arguments inside the dotfiles repo's own
script.

## Treat installCommand as a shell command line

- The first token is the script path and is still probed for existence, so a
  missing script produces a clear error.
- Remaining tokens are passed through to the script as arguments.
- The command line is no longer shell-quoted. This is safe because dotfiles
  repositories are trusted by the user who configures them; the docs now warn
  against pointing `installCommand` at untrusted content.

## Verified with unit tests

- `installCommand: "install.sh --tool"` runs `./install.sh --tool` and is not
  collapsed into a single quoted token.
- A missing script with arguments still errors and names the script.
- Existing exit-code/hint tests updated for the now-unquoted invocation.

`make test` passes and `make build` succeeds.

Generated with [Claude Code](https://claude.com/claude-code)