### PR TITLE
Add global container profiles support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Go CLI tool that runs Docker containers based on devcontainer.json configurati
 - **Container Management** - Proper labeling and workspace isolation
 - **Interactive TTY** - Full terminal support for shell sessions
 - **Personal customization** - Per-user dotfiles repository and shell override that stay out of the team's `devcontainer.json` (see [docs/dotfiles.md](docs/dotfiles.md))
+- **Global profiles** - Named, reusable container configs under your home directory for repositories that have no `devcontainer.json` (see [docs/profiles.md](docs/profiles.md))
 
 ### ❌ Not Yet Implemented
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,9 +6,17 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/garaemon/devgo/pkg/config"
 )
 
 func runInitCommand(args []string) error {
+	// When --profile is given, scaffold a reusable global profile under the
+	// home directory instead of a repo-local .devcontainer.
+	if profileName != "" {
+		return runInitProfile(profileName)
+	}
+
 	// Determine target directory
 	targetDir, err := determineInitDirectory(args)
 	if err != nil {
@@ -38,6 +46,41 @@ func runInitCommand(args []string) error {
 	}
 
 	fmt.Printf("Created devcontainer.json at %s\n", devcontainerPath)
+	return nil
+}
+
+// runInitProfile scaffolds a global container profile at
+// ~/.config/devgo/profiles/<name>/devcontainer.json. The generated template
+// uses the profile name as the devcontainer name so resulting containers are
+// easy to identify.
+func runInitProfile(name string) error {
+	devcontainerPath, err := config.ProfilePath(name)
+	if err != nil {
+		return fmt.Errorf("failed to determine profile path: %w", err)
+	}
+
+	profileDir := filepath.Dir(devcontainerPath)
+	if err := os.MkdirAll(profileDir, 0755); err != nil {
+		return fmt.Errorf("failed to create profile directory: %w", err)
+	}
+
+	if _, err := os.Stat(devcontainerPath); err == nil {
+		return fmt.Errorf("profile %q already exists at %s", name, devcontainerPath)
+	}
+
+	template := strings.Replace(
+		createDefaultTemplate(),
+		`"name": "development-container"`,
+		fmt.Sprintf(`"name": %q`, name),
+		1,
+	)
+
+	if err := os.WriteFile(devcontainerPath, []byte(template), 0644); err != nil {
+		return fmt.Errorf("failed to write profile devcontainer.json: %w", err)
+	}
+
+	fmt.Printf("Created profile %q at %s\n", name, devcontainerPath)
+	fmt.Printf("Use it from any directory with: devgo up --profile %s\n", name)
 	return nil
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -13,6 +13,12 @@ import (
 func runInitCommand(args []string) error {
 	// When --profile is given, scaffold a reusable global profile under the
 	// home directory instead of a repo-local .devcontainer.
+	//
+	// Unlike the runtime commands (up/shell/exec/...), init intentionally reads
+	// the flag variable directly instead of resolveProfileName(). Scaffolding is
+	// an explicit, one-off action, so an ambient DEVGO_PROFILE must not silently
+	// redirect a plain `devgo init` away from creating the expected local
+	// .devcontainer.
 	if profileName != "" {
 		return runInitProfile(profileName)
 	}
@@ -68,6 +74,10 @@ func runInitProfile(name string) error {
 		return fmt.Errorf("profile %q already exists at %s", name, devcontainerPath)
 	}
 
+	// Keep the literal below in sync with the "name" line in
+	// createDefaultTemplate(). If that line changes, this replacement silently
+	// matches nothing and the profile keeps the default name; the regression
+	// test in profile_test.go guards against that drift.
 	template := strings.Replace(
 		createDefaultTemplate(),
 		`"name": "development-container"`,

--- a/cmd/profile_test.go
+++ b/cmd/profile_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resetProfileGlobals clears the flag-backed globals that profile resolution
+// reads, restoring them after the test.
+func resetProfileGlobals(t *testing.T) {
+	t.Helper()
+	origProfile := profileName
+	origConfig := configPath
+	origWorkspace := workspaceFolder
+	t.Cleanup(func() {
+		profileName = origProfile
+		configPath = origConfig
+		workspaceFolder = origWorkspace
+	})
+	profileName = ""
+	configPath = ""
+	workspaceFolder = ""
+	t.Setenv("DEVGO_PROFILE", "")
+}
+
+func TestParseAllFlags_Profile(t *testing.T) {
+	resetProfileGlobals(t)
+
+	if _, err := parseAllFlags([]string{"--profile", "go", "up"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if profileName != "go" {
+		t.Errorf("profileName = %q, want %q", profileName, "go")
+	}
+}
+
+func TestResolveProfileName_FlagWinsOverEnv(t *testing.T) {
+	resetProfileGlobals(t)
+	t.Setenv("DEVGO_PROFILE", "rust")
+
+	profileName = "go"
+	if got := resolveProfileName(); got != "go" {
+		t.Errorf("resolveProfileName() = %q, want %q (flag should win)", got, "go")
+	}
+
+	profileName = ""
+	if got := resolveProfileName(); got != "rust" {
+		t.Errorf("resolveProfileName() = %q, want %q (env fallback)", got, "rust")
+	}
+}
+
+func TestFindDevcontainerConfig_Profile(t *testing.T) {
+	resetProfileGlobals(t)
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// Create a profile on disk.
+	profileDir := filepath.Join(tmp, "devgo", "profiles", "go")
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		t.Fatalf("failed to create profile dir: %v", err)
+	}
+	want := filepath.Join(profileDir, "devcontainer.json")
+	if err := os.WriteFile(want, []byte(`{"image":"alpine"}`), 0o600); err != nil {
+		t.Fatalf("failed to write profile config: %v", err)
+	}
+
+	profileName = "go"
+	got, err := findDevcontainerConfig(configPath)
+	if err != nil {
+		t.Fatalf("findDevcontainerConfig() error = %v", err)
+	}
+	if got != want {
+		t.Errorf("findDevcontainerConfig() = %q, want %q", got, want)
+	}
+}
+
+func TestFindDevcontainerConfig_ConfigBeatsProfile(t *testing.T) {
+	resetProfileGlobals(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	profileName = "go"
+	configPath = "/explicit/devcontainer.json"
+
+	got, err := findDevcontainerConfig(configPath)
+	if err != nil {
+		t.Fatalf("findDevcontainerConfig() error = %v", err)
+	}
+	if got != "/explicit/devcontainer.json" {
+		t.Errorf("findDevcontainerConfig() = %q, want explicit config path", got)
+	}
+}
+
+func TestFindDevcontainerConfig_MissingProfileError(t *testing.T) {
+	resetProfileGlobals(t)
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	// One existing profile so the error lists available profiles.
+	existing := filepath.Join(tmp, "devgo", "profiles", "rust")
+	if err := os.MkdirAll(existing, 0o755); err != nil {
+		t.Fatalf("failed to create profile dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(existing, "devcontainer.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write profile config: %v", err)
+	}
+
+	profileName = "go"
+	_, err := findDevcontainerConfig(configPath)
+	if err == nil {
+		t.Fatalf("expected error for missing profile, got nil")
+	}
+	if !strings.Contains(err.Error(), "rust") {
+		t.Errorf("error should list available profile 'rust', got: %v", err)
+	}
+}
+
+func TestDetermineWorkspaceFolder_ProfileUsesCwd(t *testing.T) {
+	resetProfileGlobals(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+
+	profileName = "go"
+	// The devcontainer path lives under the home directory; the workspace must
+	// still resolve to the current directory, not the profile's location.
+	got := determineWorkspaceFolder("/home/user/.config/devgo/profiles/go/devcontainer.json")
+	if got != cwd {
+		t.Errorf("determineWorkspaceFolder() = %q, want cwd %q", got, cwd)
+	}
+}
+
+func TestDetermineWorkspaceFolder_ProfileWorkspaceFolderOverride(t *testing.T) {
+	resetProfileGlobals(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	profileName = "go"
+	workspaceFolder = "/tmp/explicit"
+	got := determineWorkspaceFolder("/home/user/.config/devgo/profiles/go/devcontainer.json")
+	if got != "/tmp/explicit" {
+		t.Errorf("determineWorkspaceFolder() = %q, want %q", got, "/tmp/explicit")
+	}
+}

--- a/cmd/profile_test.go
+++ b/cmd/profile_test.go
@@ -116,6 +116,57 @@ func TestFindDevcontainerConfig_MissingProfileError(t *testing.T) {
 	}
 }
 
+func TestRunInitProfile_ReplacesNameWithProfileName(t *testing.T) {
+	resetProfileGlobals(t)
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if err := runInitProfile("go"); err != nil {
+		t.Fatalf("runInitProfile() error = %v", err)
+	}
+
+	generated := filepath.Join(tmp, "devgo", "profiles", "go", "devcontainer.json")
+	content, err := os.ReadFile(generated)
+	if err != nil {
+		t.Fatalf("failed to read generated profile: %v", err)
+	}
+
+	if !strings.Contains(string(content), `"name": "go"`) {
+		t.Errorf("generated profile should set name to %q, got:\n%s", "go", content)
+	}
+	if strings.Contains(string(content), `"name": "development-container"`) {
+		t.Errorf("generated profile still contains default name, got:\n%s", content)
+	}
+}
+
+func TestRunInitProfile_ErrorsWhenProfileExists(t *testing.T) {
+	resetProfileGlobals(t)
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	if err := runInitProfile("go"); err != nil {
+		t.Fatalf("first runInitProfile() error = %v", err)
+	}
+
+	err := runInitProfile("go")
+	if err == nil {
+		t.Fatalf("expected error when profile already exists, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention 'already exists', got: %v", err)
+	}
+}
+
+func TestRunInitProfile_RejectsTraversalName(t *testing.T) {
+	resetProfileGlobals(t)
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	err := runInitProfile("../escape")
+	if err == nil {
+		t.Fatalf("expected error for traversal profile name, got nil")
+	}
+}
+
 func TestDetermineWorkspaceFolder_ProfileUsesCwd(t *testing.T) {
 	resetProfileGlobals(t)
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -298,6 +298,9 @@ func resolveProfileConfig(name string) (string, error) {
 }
 
 func profileNotFoundError(name string) error {
+	// This helper only builds a friendly error message, so any failure to
+	// enumerate profiles is intentionally ignored: an empty list simply yields
+	// the "no profiles exist yet" guidance, which is an acceptable fallback.
 	available, _ := config.ListProfiles()
 	if len(available) == 0 {
 		dir, _ := config.ProfilesDir()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,15 +8,16 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/garaemon/devgo/pkg/config"
 	"github.com/garaemon/devgo/pkg/constants"
 	"github.com/garaemon/devgo/pkg/devcontainer"
-	// "github.com/garaemon/devgo/pkg/config"
 	// "github.com/garaemon/devgo/pkg/docker"
 )
 
 var (
 	workspaceFolder        string
 	configPath             string
+	profileName            string
 	forceBuild             bool
 	containerName          string
 	imageName              string
@@ -51,6 +52,9 @@ func parseAllFlags(args []string) ([]string, error) {
 			i++ // skip the next argument as it's the value
 		} else if arg == "--config" && i+1 < len(args) {
 			configPath = args[i+1]
+			i++ // skip the next argument as it's the value
+		} else if arg == "--profile" && i+1 < len(args) {
+			profileName = args[i+1]
 			i++ // skip the next argument as it's the value
 		} else if arg == "--name" && i+1 < len(args) {
 			containerName = args[i+1]
@@ -190,10 +194,16 @@ Commands:
   run-user-commands       Run user commands in container
   read-configuration      Output current workspace configuration
   init [directory]        Initialize devcontainer.json template
+                          (with --profile, scaffold a global profile instead)
 
 Flags:
   --config string
         Path to devcontainer.json file
+  --profile string
+        Use a named global profile from ~/.config/devgo/profiles/<name>/
+        instead of discovering a repo-local devcontainer.json. The current
+        directory is mounted as the workspace. Can also be set via the
+        DEVGO_PROFILE environment variable. --config takes precedence.
   --debug
         Print container lifecycle, dotfiles, and other progress messages
         to stderr. Without this flag devgo stays quiet on success.
@@ -236,6 +246,8 @@ Examples:
   devgo exec bash
   devgo shell
   devgo stop
+  devgo init --profile go        # create a reusable global profile
+  devgo up --profile go          # run it in any directory
 `)
 }
 
@@ -257,9 +269,54 @@ func runDevContainer(args []string) error {
 	return nil
 }
 
+// resolveProfileName returns the active global profile name. An explicit
+// --profile flag wins; otherwise the DEVGO_PROFILE environment variable is
+// used so a profile can be set once and reused across invocations. An empty
+// string means no profile is active (local discovery applies).
+func resolveProfileName() string {
+	if profileName != "" {
+		return profileName
+	}
+	return os.Getenv("DEVGO_PROFILE")
+}
+
+// resolveProfileConfig returns the devcontainer.json path for a named global
+// profile, or a helpful error listing available profiles if it is missing.
+func resolveProfileConfig(name string) (string, error) {
+	path, err := config.ProfilePath(name)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return "", profileNotFoundError(name)
+		}
+		return "", fmt.Errorf("failed to access profile %q: %w", name, err)
+	}
+	debugf("Using global profile %q at: %s\n", name, path)
+	return path, nil
+}
+
+func profileNotFoundError(name string) error {
+	available, _ := config.ListProfiles()
+	if len(available) == 0 {
+		dir, _ := config.ProfilesDir()
+		return fmt.Errorf(
+			"profile %q not found; no profiles exist yet. Create one with: "+
+				"devgo init --profile %s (profiles live under %s)",
+			name, name, dir)
+	}
+	return fmt.Errorf("profile %q not found; available profiles: %s",
+		name, strings.Join(available, ", "))
+}
+
 func findDevcontainerConfig(configPath string) (string, error) {
 	if configPath != "" {
 		return configPath, nil
+	}
+
+	if name := resolveProfileName(); name != "" {
+		return resolveProfileConfig(name)
 	}
 
 	cwd, err := os.Getwd()
@@ -291,6 +348,14 @@ func determineWorkspaceFolder(devcontainerPath string) string {
 			return workspaceFolder
 		}
 		return absPath
+	}
+	// In profile mode the config lives under the home directory, so the
+	// workspace cannot be derived from its location. Default to the current
+	// directory the user invoked devgo from.
+	if resolveProfileName() != "" {
+		if cwd, err := os.Getwd(); err == nil {
+			return cwd
+		}
 	}
 	// Convert to absolute path first to handle relative paths correctly
 	absPath, err := filepath.Abs(devcontainerPath)
@@ -334,9 +399,14 @@ func determineContainerName(devContainer *devcontainer.DevContainer, workspaceDi
 		session = constants.DefaultSessionName
 	}
 
+	profile := resolveProfileName()
+
 	// For docker compose, use service name with project prefix
 	if devContainer.HasDockerCompose() && devContainer.GetService() != "" {
 		projectName := sanitizeDockerName(filepath.Base(workspaceDir))
+		if profile != "" {
+			projectName = sanitizeDockerName(profile) + "-" + projectName
+		}
 		pathHash := GeneratePathHash(workspaceDir)
 		return fmt.Sprintf("%s-%s-%s-1", pathHash, projectName, devContainer.GetService())
 	}
@@ -347,6 +417,13 @@ func determineContainerName(devContainer *devcontainer.DevContainer, workspaceDi
 		baseName = sanitizeDockerName(devContainer.Name)
 	} else {
 		baseName = sanitizeDockerName(filepath.Base(workspaceDir))
+	}
+
+	// In profile mode, prefix the name with the profile so containers created
+	// from a global profile are easy to identify and never collide with a
+	// repo-local container in the same directory.
+	if profile != "" {
+		return fmt.Sprintf("%s-%s-%s-%s", sanitizeDockerName(profile), baseName, session, pathHash)
 	}
 
 	return fmt.Sprintf("%s-%s-%s", baseName, session, pathHash)

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -354,6 +354,31 @@ func TestDetermineContainerName_Profile(t *testing.T) {
 	}
 }
 
+func TestDetermineContainerName_ProfileWithCompose(t *testing.T) {
+	originalProfile := profileName
+	originalContainerName := containerName
+	defer func() {
+		profileName = originalProfile
+		containerName = originalContainerName
+	}()
+	containerName = ""
+	t.Setenv("DEVGO_PROFILE", "")
+
+	workspaceDir := "/path/to/myproj"
+	hash := GeneratePathHash(workspaceDir)
+
+	profileName = "go"
+	devContainer := &devcontainer.DevContainer{
+		DockerComposeFile: "docker-compose.yml",
+		Service:           "app",
+	}
+	result := determineContainerName(devContainer, workspaceDir)
+	expected := fmt.Sprintf("%s-go-myproj-app-1", hash)
+	if result != expected {
+		t.Errorf("expected %s but got %s", expected, result)
+	}
+}
+
 // mockDockerAPIClient implements the dockerAPIClient interface for testing
 type mockDockerAPIClient struct {
 	containers     []container.Summary

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -309,6 +309,51 @@ func TestDetermineContainerName(t *testing.T) {
 	}
 }
 
+func TestDetermineContainerName_Profile(t *testing.T) {
+	originalProfile := profileName
+	originalContainerName := containerName
+	defer func() {
+		profileName = originalProfile
+		containerName = originalContainerName
+	}()
+	containerName = ""
+	t.Setenv("DEVGO_PROFILE", "")
+
+	workspaceDir := "/path/to/myproj"
+	hash := GeneratePathHash(workspaceDir)
+
+	tests := []struct {
+		name             string
+		profile          string
+		devContainerName string
+		expected         string
+	}{
+		{
+			name:             "profile with default name from workspace",
+			profile:          "go",
+			devContainerName: "",
+			expected:         "go-myproj-default-" + hash,
+		},
+		{
+			name:             "profile with devcontainer name",
+			profile:          "rust",
+			devContainerName: "my-env",
+			expected:         "rust-my-env-default-" + hash,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profileName = tt.profile
+			devContainer := &devcontainer.DevContainer{Name: tt.devContainerName}
+			result := determineContainerName(devContainer, workspaceDir)
+			if result != tt.expected {
+				t.Errorf("expected %s but got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
 // mockDockerAPIClient implements the dockerAPIClient interface for testing
 type mockDockerAPIClient struct {
 	containers     []container.Summary

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -71,10 +71,31 @@ already behave.
 |------|----------------|
 | Local (repo `devcontainer.json`) | `<name>-<session>-<hash(workspace)>` |
 | Profile | `<profile>-<name>-<session>-<hash(workspace)>` |
+| Local + docker compose | `<hash(workspace)>-<dir>-<service>-1` |
+| Profile + docker compose | `<hash(workspace)>-<profile>-<dir>-<service>-1` |
+
+When the profile uses docker compose, the naming follows the compose project
+convention instead of the rows above: `<dir>` is the workspace directory's base
+name and `<service>` is the compose service.
 
 `<name>` is the `name` field from the profile's `devcontainer.json` (the
 scaffolded template sets it to the profile name), falling back to the workspace
-directory's base name.
+directory's base name. The `<profile>` and `<name>` segments are sanitized for
+Docker (characters outside `[a-zA-Z0-9_.-]` become `_`), so the container name
+may differ slightly from what you typed.
+
+A profile name must be a single path component: it cannot contain `/`, the
+segments `.` or `..`, or be an absolute path. This applies to both the
+`--profile` flag and the `DEVGO_PROFILE` environment variable.
+
+## Build context
+
+When a profile's `devcontainer.json` declares `dockerFile` or `build.context`,
+those paths are resolved relative to the **profile directory**
+(`~/.config/devgo/profiles/<name>/`), not the workspace you run from. A profile
+can therefore ship its own Dockerfile and build assets alongside its
+`devcontainer.json`. Only the workspace bind-mount points at your current
+directory; the build inputs always come from the profile.
 
 ## Errors
 

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,107 @@
+# Global container profiles in devgo
+
+`devgo` normally discovers a `devcontainer.json` by walking up from the current
+directory. That works great for repositories that ship their own dev container,
+but many repositories have none — and you may not want to commit one. **Global
+profiles** let you keep named container configurations under your home directory
+and run them in any directory.
+
+## How it works
+
+A profile is a directory under `~/.config/devgo/profiles/<name>/` containing a
+`devcontainer.json` (the same format as a repo-local one). When you pass
+`--profile <name>` (or set `DEVGO_PROFILE`), devgo:
+
+1. Loads `~/.config/devgo/profiles/<name>/devcontainer.json` instead of
+   searching the working tree.
+2. Mounts the **current directory** as the workspace (override with
+   `--workspace-folder`).
+3. Names the container `<profile>-<dir>-<session>-<hash>` so profile containers
+   are easy to spot and never collide with a repo-local container in the same
+   directory.
+
+The profiles directory honors `XDG_CONFIG_HOME`; when unset it defaults to
+`~/.config/devgo/profiles`.
+
+## Quick start
+
+```bash
+# Scaffold a reusable profile (creates ~/.config/devgo/profiles/go/devcontainer.json)
+devgo init --profile go
+
+# Edit the generated template to taste
+$EDITOR ~/.config/devgo/profiles/go/devcontainer.json
+
+# Use it from ANY directory
+cd ~/some/repo/without/devcontainer
+devgo up --profile go
+devgo shell --profile go
+```
+
+Set it once for a shell session and drop the flag:
+
+```bash
+export DEVGO_PROFILE=go
+devgo up        # uses the "go" profile
+devgo shell     # same
+```
+
+## Precedence
+
+When resolving which configuration to use, devgo applies this order:
+
+1. `--config <path>` — an explicit file always wins.
+2. `--profile <name>` flag.
+3. `DEVGO_PROFILE` environment variable.
+4. Local discovery (`.devcontainer/devcontainer.json` or `.devcontainer.json`
+   walking up from the current directory).
+
+So `--config` overrides any profile, and an explicit `--profile` flag overrides
+`DEVGO_PROFILE`.
+
+## Container naming and reuse
+
+Profile containers are **per-workspace**: the workspace path is hashed into the
+container name, so running `devgo up --profile go` in two different directories
+gives you two independent containers, each mounting its own directory. This
+keeps the workspace bind-mount correct and matches how repo-local containers
+already behave.
+
+| Mode | Container name |
+|------|----------------|
+| Local (repo `devcontainer.json`) | `<name>-<session>-<hash(workspace)>` |
+| Profile | `<profile>-<name>-<session>-<hash(workspace)>` |
+
+`<name>` is the `name` field from the profile's `devcontainer.json` (the
+scaffolded template sets it to the profile name), falling back to the workspace
+directory's base name.
+
+## Errors
+
+If you reference a profile that does not exist, devgo lists the profiles you do
+have:
+
+```
+$ devgo up --profile rust
+Error: profile "rust" not found; available profiles: go, node
+```
+
+When no profiles exist at all, it tells you how to create one:
+
+```
+$ devgo up --profile rust
+Error: profile "rust" not found; no profiles exist yet. Create one with:
+devgo init --profile rust (profiles live under /home/you/.config/devgo/profiles)
+```
+
+## Relationship to dotfiles
+
+Profiles and [dotfiles](dotfiles.md) are complementary:
+
+- A **profile** defines the container itself (image, build, mounts, lifecycle
+  commands) for repositories that lack a `devcontainer.json`.
+- **Dotfiles** layer your personal shell/editor setup on top of *any* container,
+  profile-based or repo-local.
+
+Both live under `~/.config/devgo/`, and dotfiles are applied after the profile's
+lifecycle commands just as they are for repo-local containers.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 type Config struct {
@@ -48,14 +49,11 @@ func Load() (*Config, error) {
 // UserConfigPath returns the path to the per-user devgo config file. It
 // honors XDG_CONFIG_HOME when set, and falls back to ~/.config/devgo/config.json.
 func UserConfigPath() (string, error) {
-	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
-		return filepath.Join(xdg, "devgo", "config.json"), nil
-	}
-	home, err := os.UserHomeDir()
+	base, err := configBaseDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to determine user home directory: %w", err)
+		return "", err
 	}
-	return filepath.Join(home, ".config", "devgo", "config.json"), nil
+	return filepath.Join(base, "config.json"), nil
 }
 
 // LoadUserConfig loads the user-global config from the default location. A
@@ -84,6 +82,70 @@ func LoadUserConfigFile(path string) (*UserConfig, error) {
 		return nil, fmt.Errorf("failed to parse user config %s: %w", path, err)
 	}
 	return &cfg, nil
+}
+
+// configBaseDir returns the directory that holds devgo's per-user
+// configuration, honoring XDG_CONFIG_HOME and falling back to ~/.config/devgo.
+func configBaseDir() (string, error) {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "devgo"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine user home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "devgo"), nil
+}
+
+// ProfilesDir returns the directory that holds named global container
+// profiles. Each profile is a subdirectory containing a devcontainer.json,
+// e.g. ~/.config/devgo/profiles/go/devcontainer.json.
+func ProfilesDir() (string, error) {
+	base, err := configBaseDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, "profiles"), nil
+}
+
+// ProfilePath returns the path to the devcontainer.json for the named global
+// profile. It does not check whether the file exists.
+func ProfilePath(name string) (string, error) {
+	dir, err := ProfilesDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, name, "devcontainer.json"), nil
+}
+
+// ListProfiles returns the names of available global profiles, sorted
+// alphabetically. A profile is a subdirectory of ProfilesDir that contains a
+// devcontainer.json. A missing profiles directory is not an error and yields
+// an empty slice.
+func ListProfiles() ([]string, error) {
+	dir, err := ProfilesDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read profiles directory %s: %w", dir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		configFile := filepath.Join(dir, entry.Name(), "devcontainer.json")
+		if _, err := os.Stat(configFile); err == nil {
+			names = append(names, entry.Name())
+		}
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 func getEnv(key, defaultValue string) string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 type Config struct {
@@ -108,9 +109,35 @@ func ProfilesDir() (string, error) {
 	return filepath.Join(base, "profiles"), nil
 }
 
+// ValidateProfileName reports whether name is usable as a single profile
+// directory component. A profile name may come from an untrusted source (the
+// --profile flag or the DEVGO_PROFILE environment variable) and is joined into
+// a filesystem path, so it must not contain path separators, traversal
+// segments, or be absolute; otherwise it could escape the profiles directory.
+func ValidateProfileName(name string) error {
+	if name == "" {
+		return fmt.Errorf("profile name must not be empty")
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("invalid profile name %q", name)
+	}
+	if filepath.IsAbs(name) ||
+		strings.ContainsRune(name, '/') ||
+		strings.ContainsRune(name, os.PathSeparator) {
+		return fmt.Errorf("profile name %q must be a single path component", name)
+	}
+	return nil
+}
+
 // ProfilePath returns the path to the devcontainer.json for the named global
-// profile. It does not check whether the file exists.
+// profile. The name must be a single path component (see ValidateProfileName);
+// path separators and traversal segments are rejected so the result always
+// stays inside the profiles directory. It does not check whether the file
+// exists.
 func ProfilePath(name string) (string, error) {
+	if err := ValidateProfileName(name); err != nil {
+		return "", err
+	}
 	dir, err := ProfilesDir()
 	if err != nil {
 		return "", err

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -235,6 +235,34 @@ func TestProfilePath_DefaultsToHome(t *testing.T) {
 	}
 }
 
+func TestProfilePath_RejectsInvalidNames(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	invalidNames := []string{
+		"",
+		".",
+		"..",
+		"../escape",
+		"foo/bar",
+		"/absolute",
+	}
+	for _, name := range invalidNames {
+		if _, err := ProfilePath(name); err == nil {
+			t.Errorf("ProfilePath(%q) expected error, got nil", name)
+		}
+	}
+}
+
+func TestValidateProfileName_AcceptsSimpleNames(t *testing.T) {
+	validNames := []string{"go", "rust", "my-profile", "profile_1", "v1.2"}
+	for _, name := range validNames {
+		if err := ValidateProfileName(name); err != nil {
+			t.Errorf("ValidateProfileName(%q) unexpected error: %v", name, err)
+		}
+	}
+}
+
 func TestListProfiles_MissingDirIsEmpty(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -205,3 +205,84 @@ func TestUserConfigPath_DefaultsToHome(t *testing.T) {
 		t.Errorf("UserConfigPath() = %q, want %q", got, want)
 	}
 }
+
+func TestProfilePath_FromXDGEnv(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	got, err := ProfilePath("go")
+	if err != nil {
+		t.Fatalf("ProfilePath() error = %v", err)
+	}
+	want := filepath.Join(tmp, "devgo", "profiles", "go", "devcontainer.json")
+	if got != want {
+		t.Errorf("ProfilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestProfilePath_DefaultsToHome(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("HOME", tmp)
+
+	got, err := ProfilePath("rust")
+	if err != nil {
+		t.Fatalf("ProfilePath() error = %v", err)
+	}
+	want := filepath.Join(tmp, ".config", "devgo", "profiles", "rust", "devcontainer.json")
+	if got != want {
+		t.Errorf("ProfilePath() = %q, want %q", got, want)
+	}
+}
+
+func TestListProfiles_MissingDirIsEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	names, err := ListProfiles()
+	if err != nil {
+		t.Fatalf("ListProfiles() error = %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("ListProfiles() = %v, want empty", names)
+	}
+}
+
+func TestListProfiles_OnlyDirsWithConfig(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	profilesDir := filepath.Join(tmp, "devgo", "profiles")
+	// Two valid profiles (go, rust), one directory without devcontainer.json
+	// (empty), and a stray file that must be ignored.
+	for _, name := range []string{"rust", "go"} {
+		dir := filepath.Join(profilesDir, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("failed to create profile dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "devcontainer.json"), []byte("{}"), 0o600); err != nil {
+			t.Fatalf("failed to write profile config: %v", err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(profilesDir, "empty"), 0o755); err != nil {
+		t.Fatalf("failed to create empty profile dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(profilesDir, "stray.json"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write stray file: %v", err)
+	}
+
+	names, err := ListProfiles()
+	if err != nil {
+		t.Fatalf("ListProfiles() error = %v", err)
+	}
+
+	want := []string{"go", "rust"} // sorted, excludes empty and stray
+	if len(names) != len(want) {
+		t.Fatalf("ListProfiles() = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("ListProfiles()[%d] = %q, want %q", i, names[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds support for **global container profiles** — named, reusable devcontainer configurations stored under `~/.config/devgo/profiles/<name>/` that can be used in any directory without committing a `devcontainer.json` to the repository.

## Key Changes

- **Profile resolution** (`cmd/root.go`):
  - Added `--profile` flag and `DEVGO_PROFILE` environment variable support
  - Implemented `resolveProfileName()` to determine active profile (flag > env var)
  - Implemented `resolveProfileConfig()` to load profile devcontainer.json with helpful error messages listing available profiles
  - Updated `findDevcontainerConfig()` to check for profiles before local discovery
  - Updated `determineWorkspaceFolder()` to use current directory as workspace when a profile is active (not the profile's location)
  - Updated `determineContainerName()` to prefix container names with profile name for easy identification and collision avoidance

- **Profile management** (`pkg/config/config.go`):
  - Added `configBaseDir()` helper to centralize XDG_CONFIG_HOME handling
  - Added `ProfilesDir()` to return `~/.config/devgo/profiles` (or `$XDG_CONFIG_HOME/devgo/profiles`)
  - Added `ProfilePath(name)` to return path to a profile's devcontainer.json
  - Added `ListProfiles()` to enumerate available profiles (sorted, only directories with devcontainer.json)

- **Profile initialization** (`cmd/init.go`):
  - Added `runInitProfile()` to scaffold global profiles with `devgo init --profile <name>`
  - Generated template uses profile name as the devcontainer name for easy container identification

- **Documentation** (`docs/profiles.md`):
  - Comprehensive guide covering how profiles work, quick start, precedence rules, container naming, error messages, and relationship to dotfiles

- **Tests**:
  - Added `cmd/profile_test.go` with 8 tests covering flag parsing, profile resolution, config discovery, missing profile errors, and workspace folder determination
  - Added 4 tests to `pkg/config/config_test.go` for ProfilePath, ListProfiles, and XDG_CONFIG_HOME handling
  - Added profile container naming tests to `cmd/up_test.go`

## Implementation Details

- **Precedence**: `--config` > `--profile` flag > `DEVGO_PROFILE` env var > local discovery
- **Container naming**: Profile containers use format `<profile>-<name>-<session>-<hash(workspace)>` to distinguish them from repo-local containers
- **Workspace isolation**: Each workspace gets its own container even when using the same profile (workspace path is hashed into container name)
- **Error handling**: Missing profiles show available alternatives or instructions to create one
- **XDG compliance**: Respects `XDG_CONFIG_HOME` environment variable, defaults to `~/.config/devgo/profiles`

https://claude.ai/code/session_01BSbvXaG4EcJmVkxKK7cEor