### PR TITLE
Add environment variable support to shell command

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,15 +255,21 @@ Values you pass override variables already defined in the container (`containerE
 
 **AWS SSO profile:**
 
-When you authenticate to AWS with a named profile via SSO, the AWS CLI can export the resolved credentials as environment variables. Export them into your current shell, then forward them all at once with the `AWS_*` wildcard:
+When you authenticate to AWS with a named profile via SSO, the AWS CLI can export the resolved credentials as environment variables. A single `--env` value may contain several newline-separated assignments (a leading `export ` is ignored), so you can pass the command output directly:
 
 ```bash
 aws sso login --profile my-sso-profile
-eval "$(aws configure export-credentials --profile my-sso-profile --format env)"
-devgo shell -e 'AWS_*'
+devgo shell --env "$(aws configure export-credentials --profile my-sso-profile --format env)"
 ```
 
-`aws configure export-credentials` turns the cached SSO login into temporary `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` values, so the AWS CLI inside the container works without mounting `~/.aws`. Add `-e AWS_REGION` (or export it before the wildcard) if you also need the region.
+`aws configure export-credentials` turns the cached SSO login into temporary `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` values, so the AWS CLI inside the container works without mounting `~/.aws`.
+
+Alternatively, export the credentials into your current shell and forward them all at once with the `AWS_*` wildcard, adding `-e AWS_REGION` if you need the region:
+
+```bash
+eval "$(aws configure export-credentials --profile my-sso-profile --format env)"
+devgo shell -e 'AWS_*' -e AWS_REGION
+```
 
 **Detach Keys:**
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ Options:
   --workspace-folder PATH    Specify workspace directory
   --shell PROGRAM            Program to launch (default /bin/bash). Overrides the
                              "shell" setting in ~/.config/devgo/config.json.
+  --env, -e KEY=VALUE        Set an environment variable in the shell session.
+                             KEY=VALUE sets an explicit value, KEY inherits it
+                             from the host environment, and PREFIX* inherits
+                             every host variable starting with PREFIX.
+                             May be repeated.
 ```
 
 **Features:**
@@ -227,6 +232,38 @@ Options:
 - Sets appropriate working directory
 - Handles signal forwarding (Ctrl+C, etc.)
 - Custom detach keys to preserve readline functionality
+
+**Passing environment variables:**
+
+Use `--env`/`-e` to inject environment variables into the shell session. Three forms are supported:
+
+```bash
+# Set an explicit value
+devgo shell --env FOO=bar
+
+# Inherit a value from the host environment (KEY with no '=')
+devgo shell -e MY_TOKEN
+
+# Inherit every host variable matching a prefix (PREFIX*)
+devgo shell -e 'AWS_*'
+
+# Repeat the flag to pass several variables
+devgo shell -e FOO=bar -e BAZ=qux
+```
+
+Values you pass override variables already defined in the container (`containerEnv`).
+
+**AWS SSO profile:**
+
+When you authenticate to AWS with a named profile via SSO, the AWS CLI can export the resolved credentials as environment variables. Export them into your current shell, then forward them all at once with the `AWS_*` wildcard:
+
+```bash
+aws sso login --profile my-sso-profile
+eval "$(aws configure export-credentials --profile my-sso-profile --format env)"
+devgo shell -e 'AWS_*'
+```
+
+`aws configure export-credentials` turns the cached SSO login into temporary `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` values, so the AWS CLI inside the container works without mounting `~/.aws`. Add `-e AWS_REGION` (or export it before the wildcard) if you also need the region.
 
 **Detach Keys:**
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ var (
 	noDotfiles             bool
 	forceDotfiles          bool
 	shellOverride          string
+	shellEnvVars           []string
 )
 
 // parseAllFlags parses all flags from the argument list, returning non-flag arguments
@@ -82,6 +83,9 @@ func parseAllFlags(args []string) ([]string, error) {
 			forceDotfiles = true
 		} else if arg == "--shell" && i+1 < len(args) {
 			shellOverride = args[i+1]
+			i++
+		} else if (arg == "--env" || arg == "-e") && i+1 < len(args) {
+			shellEnvVars = append(shellEnvVars, args[i+1])
 			i++
 		} else if len(arg) > 2 && arg[:2] == "--" {
 			// Check if this is an unknown flag
@@ -229,12 +233,24 @@ Flags:
         Re-clone the dotfiles repository even if the target path already exists
   --shell string
         Program to launch for 'devgo shell' (overrides shell setting in user config; defaults to /bin/bash)
+  --env, -e KEY=VALUE
+        Set an environment variable in the 'devgo shell' session. Forms:
+          KEY=VALUE   set an explicit value
+          KEY         inherit the value from the host environment
+          PREFIX*     inherit every host variable whose name starts with PREFIX
+        May be repeated. User values override container values. For an AWS SSO
+        profile, export the credentials into your shell first, then forward them
+        in one go:
+          eval "$(aws configure export-credentials --format env)"
+          devgo shell -e 'AWS_*'
 
 Examples:
   devgo up --workspace-folder .
   devgo build --image-name myapp:latest
   devgo exec bash
   devgo shell
+  devgo shell --env FOO=bar -e PATH
+  devgo shell -e 'AWS_*'
   devgo stop
 `)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -238,11 +238,11 @@ Flags:
           KEY=VALUE   set an explicit value
           KEY         inherit the value from the host environment
           PREFIX*     inherit every host variable whose name starts with PREFIX
-        May be repeated. User values override container values. For an AWS SSO
-        profile, export the credentials into your shell first, then forward them
-        in one go:
-          eval "$(aws configure export-credentials --format env)"
-          devgo shell -e 'AWS_*'
+        A single value may contain several newline-separated assignments and a
+        leading 'export ' is ignored, so AWS SSO credentials can be passed in
+        one shot:
+          devgo shell --env "$(aws configure export-credentials --format env)"
+        May be repeated. User values override container values.
 
 Examples:
   devgo up --workspace-folder .
@@ -250,7 +250,7 @@ Examples:
   devgo exec bash
   devgo shell
   devgo shell --env FOO=bar -e PATH
-  devgo shell -e 'AWS_*'
+  devgo shell --env "$(aws configure export-credentials --format env)"
   devgo stop
 `)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -275,6 +275,44 @@ func TestParseAllFlags_ShellFlag(t *testing.T) {
 	}
 }
 
+func TestParseAllFlags_EnvFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "single --env",
+			args: []string{"shell", "--env", "FOO=bar"},
+			want: []string{"FOO=bar"},
+		},
+		{
+			name: "repeated --env and -e",
+			args: []string{"shell", "--env", "FOO=bar", "-e", "BAZ=qux", "-e", "PATH"},
+			want: []string{"FOO=bar", "BAZ=qux", "PATH"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shellEnvVars = nil
+			defer func() { shellEnvVars = nil }()
+
+			if _, err := parseAllFlags(tt.args); err != nil {
+				t.Fatalf("parseAllFlags error = %v", err)
+			}
+			if len(shellEnvVars) != len(tt.want) {
+				t.Fatalf("shellEnvVars = %v, want %v", shellEnvVars, tt.want)
+			}
+			for i, v := range tt.want {
+				if shellEnvVars[i] != v {
+					t.Errorf("shellEnvVars[%d] = %q, want %q", i, shellEnvVars[i], v)
+				}
+			}
+		})
+	}
+}
+
 func TestParseAllFlags_DotfilesFlags(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -66,10 +66,69 @@ func runShellCommand(args []string) error {
 	shellCommand := resolveShellCommand(shellOverride, userConfig)
 
 	ctx := context.Background()
-	return executeInteractiveShell(ctx, cli, containerName, devContainer, shellCommand)
+	return executeInteractiveShell(ctx, cli, containerName, devContainer, shellCommand, shellEnvVars)
 }
 
-func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containerName string, devContainer *devcontainer.DevContainer, shellCommand []string) error {
+// resolveEnvVars parses --env/-e entries into a map of variables. Each entry
+// is one of:
+//
+//	KEY=VALUE   set an explicit value
+//	KEY         inherit the value from the host environment (skipped if unset)
+//	PREFIX*     inherit every host variable whose name starts with PREFIX
+//
+// The wildcard form makes it easy to forward a related group of variables, e.g.
+// after `eval "$(aws configure export-credentials --format env)"` a single
+// `-e 'AWS_*'` forwards all the resulting AWS_ credentials into the shell.
+func resolveEnvVars(entries []string) map[string]string {
+	resolved := make(map[string]string)
+	for _, e := range entries {
+		switch {
+		case e == "":
+			continue
+		case strings.Contains(e, "="):
+			idx := strings.IndexByte(e, '=')
+			resolved[e[:idx]] = e[idx+1:]
+		case strings.HasSuffix(e, "*"):
+			prefix := strings.TrimSuffix(e, "*")
+			for _, kv := range os.Environ() {
+				idx := strings.IndexByte(kv, '=')
+				if idx < 0 {
+					continue
+				}
+				if key := kv[:idx]; strings.HasPrefix(key, prefix) {
+					resolved[key] = kv[idx+1:]
+				}
+			}
+		default:
+			if val, ok := os.LookupEnv(e); ok {
+				resolved[e] = val
+			}
+		}
+	}
+	return resolved
+}
+
+// buildShellEnv builds the environment slice passed to the shell exec. It
+// starts from the container's resolved environment, defaults TERM to
+// xterm-256color, then overlays user-supplied --env entries (which override
+// container values).
+func buildShellEnv(expandedEnv map[string]string, extraEnv []string) []string {
+	merged := map[string]string{"TERM": "xterm-256color"}
+	for k, v := range expandedEnv {
+		merged[k] = v
+	}
+	for k, v := range resolveEnvVars(extraEnv) {
+		merged[k] = v
+	}
+
+	env := make([]string, 0, len(merged))
+	for k, v := range merged {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}
+
+func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containerName string, devContainer *devcontainer.DevContainer, shellCommand []string, extraEnv []string) error {
 	containerID, err := findRunningContainer(ctx, cli, containerName)
 	if err != nil {
 		return fmt.Errorf("failed to find running container: %w", err)
@@ -94,12 +153,9 @@ func executeInteractiveShell(ctx context.Context, cli DockerExecClient, containe
 	}
 
 	expandedEnv := devContainer.GetContainerEnv(baseEnv)
-	var env []string
-	// TERM should be set based on the current terminal, but xterm-256color is a safe default
-	env = append(env, "TERM=xterm-256color")
-	for k, v := range expandedEnv {
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
+	// TERM defaults to xterm-256color; user-supplied --env entries override
+	// container values.
+	env := buildShellEnv(expandedEnv, extraEnv)
 
 	user := devContainer.GetTargetUser()
 	workspaceFolder := devContainer.GetWorkspaceFolder()

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -69,39 +69,45 @@ func runShellCommand(args []string) error {
 	return executeInteractiveShell(ctx, cli, containerName, devContainer, shellCommand, shellEnvVars)
 }
 
-// resolveEnvVars parses --env/-e entries into a map of variables. Each entry
-// is one of:
+// resolveEnvVars parses --env/-e entries into a map of variables. A single
+// entry may contain several newline-separated assignments, and a leading
+// "export " on each line is ignored, so the output of
+// `aws configure export-credentials --format env` can be passed verbatim:
+//
+//	devgo shell --env "$(aws configure export-credentials --format env)"
+//
+// Each (line) is one of:
 //
 //	KEY=VALUE   set an explicit value
 //	KEY         inherit the value from the host environment (skipped if unset)
 //	PREFIX*     inherit every host variable whose name starts with PREFIX
-//
-// The wildcard form makes it easy to forward a related group of variables, e.g.
-// after `eval "$(aws configure export-credentials --format env)"` a single
-// `-e 'AWS_*'` forwards all the resulting AWS_ credentials into the shell.
 func resolveEnvVars(entries []string) map[string]string {
 	resolved := make(map[string]string)
-	for _, e := range entries {
-		switch {
-		case e == "":
-			continue
-		case strings.Contains(e, "="):
-			idx := strings.IndexByte(e, '=')
-			resolved[e[:idx]] = e[idx+1:]
-		case strings.HasSuffix(e, "*"):
-			prefix := strings.TrimSuffix(e, "*")
-			for _, kv := range os.Environ() {
-				idx := strings.IndexByte(kv, '=')
-				if idx < 0 {
-					continue
+	for _, entry := range entries {
+		for _, line := range strings.Split(entry, "\n") {
+			// Tolerate a leading 'export ' so '--format env' output works as-is.
+			e := strings.TrimPrefix(strings.TrimSpace(line), "export ")
+			switch {
+			case e == "":
+				continue
+			case strings.Contains(e, "="):
+				idx := strings.IndexByte(e, '=')
+				resolved[e[:idx]] = e[idx+1:]
+			case strings.HasSuffix(e, "*"):
+				prefix := strings.TrimSuffix(e, "*")
+				for _, kv := range os.Environ() {
+					idx := strings.IndexByte(kv, '=')
+					if idx < 0 {
+						continue
+					}
+					if key := kv[:idx]; strings.HasPrefix(key, prefix) {
+						resolved[key] = kv[idx+1:]
+					}
 				}
-				if key := kv[:idx]; strings.HasPrefix(key, prefix) {
-					resolved[key] = kv[idx+1:]
+			default:
+				if val, ok := os.LookupEnv(e); ok {
+					resolved[e] = val
 				}
-			}
-		default:
-			if val, ok := os.LookupEnv(e); ok {
-				resolved[e] = val
 			}
 		}
 	}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -76,23 +76,39 @@ func runShellCommand(args []string) error {
 //
 //	devgo shell --env "$(aws configure export-credentials --format env)"
 //
-// Each (line) is one of:
+// Each line is one of:
 //
 //	KEY=VALUE   set an explicit value
 //	KEY         inherit the value from the host environment (skipped if unset)
 //	PREFIX*     inherit every host variable whose name starts with PREFIX
+//
+// For the KEY=VALUE form the value is preserved exactly (including embedded and
+// trailing whitespace); only the key side is trimmed, since environment
+// variable names never contain whitespace. Later assignments to the same key
+// win.
 func resolveEnvVars(entries []string) map[string]string {
 	resolved := make(map[string]string)
 	for _, entry := range entries {
 		for _, line := range strings.Split(entry, "\n") {
-			// Tolerate a leading 'export ' so '--format env' output works as-is.
-			e := strings.TrimPrefix(strings.TrimSpace(line), "export ")
+			// Drop a trailing CR so CRLF input is handled, but otherwise keep
+			// the line intact so values retain their internal/trailing spaces.
+			line = strings.TrimSuffix(line, "\r")
+
+			if idx := strings.IndexByte(line, '='); idx >= 0 {
+				key := strings.TrimSpace(line[:idx])
+				key = strings.TrimSpace(strings.TrimPrefix(key, "export "))
+				if key != "" {
+					resolved[key] = line[idx+1:]
+				}
+				continue
+			}
+
+			// No '=': an inherit (KEY) or wildcard (PREFIX*) form. These are
+			// typed by the user, so trimming surrounding whitespace is safe.
+			e := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "export "))
 			switch {
 			case e == "":
 				continue
-			case strings.Contains(e, "="):
-				idx := strings.IndexByte(e, '=')
-				resolved[e[:idx]] = e[idx+1:]
 			case strings.HasSuffix(e, "*"):
 				prefix := strings.TrimSuffix(e, "*")
 				for _, kv := range os.Environ() {

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -304,6 +304,30 @@ func TestResolveEnvVars_Wildcard(t *testing.T) {
 	}
 }
 
+func TestResolveEnvVars_MultilineExport(t *testing.T) {
+	// Simulates `--env "$(aws configure export-credentials --format env)"`,
+	// whose output is several `export KEY=VALUE` lines in one argument.
+	blob := "export AWS_ACCESS_KEY_ID=ASIAEXAMPLE\n" +
+		"export AWS_SECRET_ACCESS_KEY=secret\n" +
+		"export AWS_SESSION_TOKEN=token\n"
+
+	got := resolveEnvVars([]string{blob})
+
+	want := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "ASIAEXAMPLE",
+		"AWS_SECRET_ACCESS_KEY": "secret",
+		"AWS_SESSION_TOKEN":     "token",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("resolveEnvVars() = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("resolveEnvVars()[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
 func TestResolveShellCommand(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -328,6 +328,193 @@ func TestResolveEnvVars_MultilineExport(t *testing.T) {
 	}
 }
 
+// TestResolveEnvVars_EdgeCases covers tricky parsing situations, especially
+// whitespace handling in values, which must be preserved exactly.
+func TestResolveEnvVars_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		wantKey string
+		wantVal string
+	}{
+		{
+			name:    "value with embedded spaces",
+			entries: []string{"GREETING=hello world"},
+			wantKey: "GREETING",
+			wantVal: "hello world",
+		},
+		{
+			name:    "value with trailing spaces is preserved",
+			entries: []string{"PADDED=value   "},
+			wantKey: "PADDED",
+			wantVal: "value   ",
+		},
+		{
+			name:    "value with leading spaces is preserved",
+			entries: []string{"PADDED=   value"},
+			wantKey: "PADDED",
+			wantVal: "   value",
+		},
+		{
+			name:    "value with tabs is preserved",
+			entries: []string{"TABBED=a\tb"},
+			wantKey: "TABBED",
+			wantVal: "a\tb",
+		},
+		{
+			name:    "value containing equals signs",
+			entries: []string{"QUERY=a=b=c"},
+			wantKey: "QUERY",
+			wantVal: "a=b=c",
+		},
+		{
+			name:    "empty value",
+			entries: []string{"EMPTY="},
+			wantKey: "EMPTY",
+			wantVal: "",
+		},
+		{
+			name:    "value of only spaces is preserved",
+			entries: []string{"SPACES=   "},
+			wantKey: "SPACES",
+			wantVal: "   ",
+		},
+		{
+			name:    "export prefix is stripped",
+			entries: []string{"export FOO=bar"},
+			wantKey: "FOO",
+			wantVal: "bar",
+		},
+		{
+			name:    "export prefix with extra spaces before key",
+			entries: []string{"export   FOO=bar"},
+			wantKey: "FOO",
+			wantVal: "bar",
+		},
+		{
+			name:    "leading indentation before key is trimmed",
+			entries: []string{"   FOO=bar"},
+			wantKey: "FOO",
+			wantVal: "bar",
+		},
+		{
+			name:    "key with surrounding spaces is trimmed",
+			entries: []string{"  FOO  =bar"},
+			wantKey: "FOO",
+			wantVal: "bar",
+		},
+		{
+			name:    "CRLF line ending strips the carriage return",
+			entries: []string{"FOO=bar\r"},
+			wantKey: "FOO",
+			wantVal: "bar",
+		},
+		{
+			name:    "value that itself looks like an export statement",
+			entries: []string{"CMD=export FOO=bar"},
+			wantKey: "CMD",
+			wantVal: "export FOO=bar",
+		},
+		{
+			name:    "later assignment wins",
+			entries: []string{"FOO=first", "FOO=second"},
+			wantKey: "FOO",
+			wantVal: "second",
+		},
+		{
+			name:    "later assignment within a multiline blob wins",
+			entries: []string{"FOO=first\nFOO=second"},
+			wantKey: "FOO",
+			wantVal: "second",
+		},
+		{
+			name:    "value with a literal newline-like backslash sequence is kept",
+			entries: []string{`FOO=a\nb`},
+			wantKey: "FOO",
+			wantVal: `a\nb`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveEnvVars(tt.entries)
+			if v, ok := got[tt.wantKey]; !ok {
+				t.Fatalf("resolveEnvVars() missing key %q (got %v)", tt.wantKey, got)
+			} else if v != tt.wantVal {
+				t.Errorf("resolveEnvVars()[%q] = %q, want %q", tt.wantKey, v, tt.wantVal)
+			}
+		})
+	}
+}
+
+// TestResolveEnvVars_Skips checks inputs that should not produce any variable.
+func TestResolveEnvVars_Skips(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+	}{
+		{name: "empty string", entries: []string{""}},
+		{name: "whitespace only line", entries: []string{"   "}},
+		{name: "blank lines in a blob", entries: []string{"\n\n  \n"}},
+		{name: "bare export keyword", entries: []string{"export "}},
+		{name: "line with only equals and no key", entries: []string{"=novalue"}},
+		{name: "line with only spaces before equals", entries: []string{"   =x"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveEnvVars(tt.entries)
+			if len(got) != 0 {
+				t.Errorf("resolveEnvVars(%q) = %v, want empty", tt.entries, got)
+			}
+		})
+	}
+}
+
+// TestResolveEnvVars_BlobWithBlankAndExportLines mirrors the real AWS CLI
+// output, which can include blank lines and an expiration field.
+func TestResolveEnvVars_BlobWithBlankAndExportLines(t *testing.T) {
+	blob := "\n" +
+		"export AWS_ACCESS_KEY_ID=ASIAEXAMPLE\n" +
+		"\n" +
+		"export AWS_SECRET_ACCESS_KEY=secret/with+slashes\n" +
+		"export AWS_SESSION_TOKEN=token==\n" +
+		"export AWS_CREDENTIAL_EXPIRATION=2026-06-27T00:00:00+00:00\n"
+
+	got := resolveEnvVars([]string{blob})
+
+	want := map[string]string{
+		"AWS_ACCESS_KEY_ID":         "ASIAEXAMPLE",
+		"AWS_SECRET_ACCESS_KEY":     "secret/with+slashes",
+		"AWS_SESSION_TOKEN":         "token==",
+		"AWS_CREDENTIAL_EXPIRATION": "2026-06-27T00:00:00+00:00",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("resolveEnvVars() = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("resolveEnvVars()[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+// TestBuildShellEnv_PreservesWhitespaceValue verifies a value with spaces
+// survives end-to-end into the exec env slice as a single entry.
+func TestBuildShellEnv_PreservesWhitespaceValue(t *testing.T) {
+	env := buildShellEnv(nil, []string{"MSG=hello world  "})
+
+	found := false
+	for _, e := range env {
+		if e == "MSG=hello world  " {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected %q in env, got %v", "MSG=hello world  ", env)
+	}
+}
+
 func TestResolveShellCommand(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/shell_test.go
+++ b/cmd/shell_test.go
@@ -144,7 +144,7 @@ func TestExecuteInteractiveShell(t *testing.T) {
 				inspectResponse:    tt.inspectResponse,
 			}
 
-			err := executeInteractiveShell(context.Background(), mockClient, tt.containerName, tt.devContainer, []string{"/bin/bash", "-i"})
+			err := executeInteractiveShell(context.Background(), mockClient, tt.containerName, tt.devContainer, []string{"/bin/bash", "-i"}, nil)
 
 			if tt.expectError {
 				if err == nil {
@@ -161,6 +161,146 @@ func TestExecuteInteractiveShell(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestResolveEnvVars(t *testing.T) {
+	t.Setenv("DEVGO_TEST_HOST_VAR", "from_host")
+
+	got := resolveEnvVars([]string{
+		"FOO=bar",
+		"EMPTY=",
+		"WITH=equals=sign",
+		"DEVGO_TEST_HOST_VAR",
+		"DEVGO_TEST_UNSET_VAR",
+		"",
+	})
+
+	want := map[string]string{
+		"FOO":                 "bar",
+		"EMPTY":               "",
+		"WITH":                "equals=sign",
+		"DEVGO_TEST_HOST_VAR": "from_host",
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("resolveEnvVars() = %v, want %v", got, want)
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("resolveEnvVars()[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	if _, ok := got["DEVGO_TEST_UNSET_VAR"]; ok {
+		t.Errorf("unset host var should be skipped, but it was present")
+	}
+}
+
+func TestBuildShellEnv(t *testing.T) {
+	toMap := func(env []string) map[string]string {
+		m := make(map[string]string)
+		for _, e := range env {
+			parts := strings.SplitN(e, "=", 2)
+			if len(parts) == 2 {
+				m[parts[0]] = parts[1]
+			}
+		}
+		return m
+	}
+
+	t.Run("defaults TERM when not provided", func(t *testing.T) {
+		got := toMap(buildShellEnv(nil, nil))
+		if got["TERM"] != "xterm-256color" {
+			t.Errorf("TERM = %q, want xterm-256color", got["TERM"])
+		}
+	})
+
+	t.Run("includes container env", func(t *testing.T) {
+		got := toMap(buildShellEnv(map[string]string{"PATH": "/usr/bin"}, nil))
+		if got["PATH"] != "/usr/bin" {
+			t.Errorf("PATH = %q, want /usr/bin", got["PATH"])
+		}
+	})
+
+	t.Run("user env overrides container env", func(t *testing.T) {
+		got := toMap(buildShellEnv(
+			map[string]string{"FOO": "container"},
+			[]string{"FOO=user", "BAR=baz"},
+		))
+		if got["FOO"] != "user" {
+			t.Errorf("FOO = %q, want user (override)", got["FOO"])
+		}
+		if got["BAR"] != "baz" {
+			t.Errorf("BAR = %q, want baz", got["BAR"])
+		}
+	})
+
+	t.Run("user env can override TERM", func(t *testing.T) {
+		got := toMap(buildShellEnv(nil, []string{"TERM=dumb"}))
+		if got["TERM"] != "dumb" {
+			t.Errorf("TERM = %q, want dumb", got["TERM"])
+		}
+	})
+}
+
+func TestShellCommand_PassesExtraEnv(t *testing.T) {
+	devContainer := &devcontainer.DevContainer{
+		ContainerUser:   "testuser",
+		WorkspaceFolder: "/workspace",
+	}
+	containers := []container.Summary{
+		{
+			ID:    "test123",
+			Names: []string{"/test-container"},
+			Labels: map[string]string{
+				constants.DevgoManagedLabel: constants.DevgoManagedValue,
+			},
+		},
+	}
+	baseMockClient := &mockExecClient{
+		containers:         containers,
+		execCreateResponse: container.ExecCreateResponse{ID: "exec123"},
+		execAttachResponse: createMockHijackedResponse(),
+		inspectResponse: types.ContainerJSON{
+			Config: &container.Config{Env: []string{"PATH=/usr/bin"}},
+		},
+	}
+	mockClient := &mockShellExecClient{mockExecClient: baseMockClient}
+
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer,
+		[]string{"/bin/bash", "-i"}, []string{"FOO=bar"})
+
+	found := false
+	for _, e := range mockClient.capturedExecOptions.Env {
+		if e == "FOO=bar" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected FOO=bar in exec env, got %v", mockClient.capturedExecOptions.Env)
+	}
+}
+
+func TestResolveEnvVars_Wildcard(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "ASIAEXAMPLE")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+	t.Setenv("AWS_SESSION_TOKEN", "token")
+	t.Setenv("NOT_AWS_VAR", "ignored")
+
+	got := resolveEnvVars([]string{"AWS_*"})
+
+	want := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "ASIAEXAMPLE",
+		"AWS_SECRET_ACCESS_KEY": "secret",
+		"AWS_SESSION_TOKEN":     "token",
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("resolveEnvVars()[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+	if _, ok := got["NOT_AWS_VAR"]; ok {
+		t.Errorf("wildcard AWS_* should not match NOT_AWS_VAR")
 	}
 }
 
@@ -242,7 +382,7 @@ func TestShellCommand_FallsBackToContainerUser(t *testing.T) {
 	}
 	mockClient := &mockShellExecClient{mockExecClient: baseMockClient}
 
-	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"}, nil)
 
 	if mockClient.capturedExecOptions.User != "node" {
 		t.Errorf("expected shell to fall back to containerUser %q, got %q", "node", mockClient.capturedExecOptions.User)
@@ -274,7 +414,7 @@ func TestShellCommand_PrefersRemoteUser(t *testing.T) {
 	}
 	mockClient := &mockShellExecClient{mockExecClient: baseMockClient}
 
-	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"}, nil)
 
 	if mockClient.capturedExecOptions.User != "vscode" {
 		t.Errorf("expected shell to run as remoteUser %q, got %q", "vscode", mockClient.capturedExecOptions.User)
@@ -305,7 +445,7 @@ func TestShellCommand_UsesResolvedShell(t *testing.T) {
 	}
 	mockClient := &mockShellExecClient{mockExecClient: baseMockClient}
 
-	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"zsh", "-i"})
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"zsh", "-i"}, nil)
 
 	got := mockClient.capturedExecOptions.Cmd
 	want := []string{"zsh", "-i"}
@@ -378,7 +518,7 @@ func TestShellCommandExecOptions(t *testing.T) {
 	}
 
 	// This will fail due to terminal handling, but we can still test the exec options
-	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"}, nil)
 
 	// Verify exec options are set correctly for shell command
 	capturedExecOptions := mockClient.capturedExecOptions
@@ -489,7 +629,7 @@ func TestShellRespectsBashrc(t *testing.T) {
 		mockExecClient: baseMockClient,
 	}
 
-	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"})
+	_ = executeInteractiveShell(context.Background(), mockClient, "test-container", devContainer, []string{"/bin/bash", "-i"}, nil)
 
 	capturedExecOptions := mockClient.capturedExecOptions
 


### PR DESCRIPTION
## Summary

Add `--env`/`-e` flag support to the `devgo shell` command, allowing users to inject environment variables into the shell session. This enables convenient credential passing for AWS SSO and other use cases without mounting sensitive files into the container.

## Key Changes

- **New `--env`/`-e` flag**: Accepts three forms of environment variable specifications:
  - `KEY=VALUE` - Set an explicit value
  - `KEY` - Inherit from host environment (skipped if unset)
  - `PREFIX*` - Inherit all host variables matching the prefix pattern

- **`resolveEnvVars()` function**: Parses environment variable entries with support for:
  - Multiline input (e.g., output from `aws configure export-credentials`)
  - `export` keyword prefix stripping (for shell command output compatibility)
  - Wildcard pattern matching for variable prefixes
  - Exact whitespace preservation in values (including trailing/leading spaces)
  - CRLF line ending handling

- **`buildShellEnv()` function**: Constructs the final environment slice by:
  - Starting with container's resolved environment
  - Defaulting `TERM` to `xterm-256color`
  - Overlaying user-supplied `--env` entries (which override container values)

- **Flag parsing**: Updated `parseAllFlags()` in `cmd/root.go` to handle repeated `--env`/`-e` flags

- **Integration**: Modified `executeInteractiveShell()` signature to accept `extraEnv` parameter and pass resolved variables to the Docker exec call

## Implementation Details

The `resolveEnvVars()` function handles complex parsing scenarios:
- Supports AWS CLI output format: `export AWS_ACCESS_KEY_ID=value\nexport AWS_SECRET_ACCESS_KEY=value`
- Preserves values exactly as provided (spaces, special characters, equals signs)
- Trims only the key side and `export` prefix, never the value
- Later assignments to the same key override earlier ones
- Skips empty lines and unset host variables

Comprehensive test coverage includes edge cases for whitespace handling, multiline blobs, wildcard matching, and AWS credential export format compatibility.

## Documentation

Updated README with usage examples including:
- Basic environment variable passing
- AWS SSO credential injection via command substitution
- Wildcard variable forwarding
- Multiple flag repetition

https://claude.ai/code/session_01NifiKBmnJwrQiS46v6DeVz