### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -256,7 +256,7 @@ Examples:
 }
 
 func showVersionInfo() {
-	fmt.Println("devgo version 0.3.0")
+	fmt.Println("devgo version 0.4.0")
 }
 
 func runDevContainer(args []string) error {


### PR DESCRIPTION
Bump the version from 0.3.0 to 0.4.0 for the next release.

## What's Changed since v0.3.0

- feat(shell): add `--env/-e` flag to pass environment variables, with support for multi-line `export KEY=VALUE` blobs and whitespace preservation (#74)
- Add release skill documenting the version release workflow (#72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)