### PR TITLE
Add Podman runtime support with Docker/Podman selection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,9 @@ jobs:
         sudo mkdir -p "${XDG_RUNTIME_DIR}"
         sudo chown "$(id -u):$(id -g)" "${XDG_RUNTIME_DIR}"
         sudo chmod 700 "${XDG_RUNTIME_DIR}"
+        # The service binds the socket at $XDG_RUNTIME_DIR/podman/podman.sock, so
+        # its parent directory must exist before 'podman system service' runs.
+        mkdir -p "${XDG_RUNTIME_DIR}/podman"
         SOCK="${XDG_RUNTIME_DIR}/podman/podman.sock"
         podman system service --time=0 "unix://${SOCK}" &
         SERVICE_PID=$!

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,71 @@ jobs:
       run: |
         cd test/integration
         go test -v -timeout=300s
-        
+
+  integration-podman:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-mod-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Build
+      run: make build
+
+    - name: Ensure Podman is installed
+      run: |
+        if ! command -v podman >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y podman
+        fi
+        podman version
+
+    # Bring up Podman's Docker-compatible API socket and run the integration
+    # suite against it. The service and the tests share one step so the
+    # background service is guaranteed alive for the whole run. Setting
+    # DEVGO_CONTAINER_RUNTIME=podman makes both the devgo binary under test and
+    # the tests' own helper commands (ps, inspect, exec, ...) drive Podman.
+    - name: Run integration tests with Podman
+      env:
+        DEVGO_CONTAINER_RUNTIME: podman
+      run: |
+        export XDG_RUNTIME_DIR="${HOME}/.podman-run"
+        mkdir -p "${XDG_RUNTIME_DIR}"
+        chmod 700 "${XDG_RUNTIME_DIR}"
+        SOCK="${XDG_RUNTIME_DIR}/podman.sock"
+        podman system service --time=0 "unix://${SOCK}" &
+        SERVICE_PID=$!
+        for _ in $(seq 1 15); do
+          [ -S "${SOCK}" ] && break
+          sleep 1
+        done
+        if [ ! -S "${SOCK}" ]; then
+          echo "Podman API socket did not appear"
+          podman info || true
+          exit 1
+        fi
+        export DOCKER_HOST="unix://${SOCK}"
+        cd test/integration
+        go test -v -timeout=300s
+        status=$?
+        kill "${SERVICE_PID}" 2>/dev/null || true
+        exit $status
+
   lint:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,10 +128,19 @@ jobs:
       env:
         DEVGO_CONTAINER_RUNTIME: podman
       run: |
-        export XDG_RUNTIME_DIR="${HOME}/.podman-run"
-        mkdir -p "${XDG_RUNTIME_DIR}"
-        chmod 700 "${XDG_RUNTIME_DIR}"
-        SOCK="${XDG_RUNTIME_DIR}/podman.sock"
+        # Rootless Podman's network backend (netavark) writes its IPAM state to
+        # /run/user/<uid>/containers/networks regardless of XDG_RUNTIME_DIR, and
+        # GitHub runners have no login session to create /run/user/<uid>. Create
+        # and own it up front so container networking works, then start Podman's
+        # Docker-compatible API socket there. Running the service and the tests
+        # in one step keeps the background service alive for the whole run, and
+        # DEVGO_CONTAINER_RUNTIME=podman makes both the devgo binary under test
+        # and the tests' helper commands (ps, inspect, exec, ...) drive Podman.
+        export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+        sudo mkdir -p "${XDG_RUNTIME_DIR}"
+        sudo chown "$(id -u):$(id -g)" "${XDG_RUNTIME_DIR}"
+        sudo chmod 700 "${XDG_RUNTIME_DIR}"
+        SOCK="${XDG_RUNTIME_DIR}/podman/podman.sock"
         podman system service --time=0 "unix://${SOCK}" &
         SERVICE_PID=$!
         for _ in $(seq 1 15); do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`devgo` is a Go CLI tool that runs Docker containers based on devcontainer.json configuration files. It automatically discovers devcontainer configurations and executes commands inside the appropriate container environment.
+`devgo` is a Go CLI tool that runs Docker or Podman containers based on devcontainer.json configuration files. It automatically discovers devcontainer configurations and executes commands inside the appropriate container environment. The container runtime is selectable via the `--runtime` flag, the `DEVGO_CONTAINER_RUNTIME` environment variable, or the `containerRuntime` field in `~/.config/devgo/config.json` (see `cmd/runtime.go`).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # devgo
 
-A Go CLI tool that runs Docker containers based on devcontainer.json configuration files. `devgo` provides compatibility with the official DevContainer CLI, offering a lightweight alternative for managing development containers.
+A Go CLI tool that runs Docker or Podman containers based on devcontainer.json configuration files. `devgo` provides compatibility with the official DevContainer CLI, offering a lightweight alternative for managing development containers.
 
 ## Features
 
@@ -17,6 +17,7 @@ A Go CLI tool that runs Docker containers based on devcontainer.json configurati
 
 ### ✅ Advanced Features
 
+- **Docker & Podman Runtimes** - Use Docker (default) or Podman via `--runtime`, `DEVGO_CONTAINER_RUNTIME`, or user config (see [Container Runtime](#container-runtime-docker--podman))
 - **Docker Compose Support** - Single and multiple compose files
 - **Lifecycle Commands** - Full support for onCreate, updateContent, postCreate, postStart, postAttach
 - **initializeCommand** - Host-side command execution before container creation
@@ -472,6 +473,63 @@ The `vscode` user's UID/GID will be updated to match your host user, allowing se
 }
 ```
 The `node` user will have the correct permissions to install npm packages and access workspace files.
+
+## Container Runtime (Docker / Podman)
+
+`devgo` drives Docker by default but can use [Podman](https://podman.io/) instead. Podman
+exposes a Docker-compatible API and CLI, so the same devcontainer.json configurations work
+with either runtime.
+
+### Selecting the runtime
+
+The runtime is resolved in the following order of precedence (highest first):
+
+1. The `--runtime` flag: `devgo --runtime podman up`
+2. The `DEVGO_CONTAINER_RUNTIME` environment variable: `export DEVGO_CONTAINER_RUNTIME=podman`
+3. The `containerRuntime` field in `~/.config/devgo/config.json`:
+
+   ```json
+   {
+     "containerRuntime": "podman"
+   }
+   ```
+
+4. The default, `docker`.
+
+Accepted values are `docker` and `podman`.
+
+### How it works
+
+- **CLI operations** (`devgo build`, image push, and Docker Compose) invoke the selected
+  binary directly (`podman build`, `podman compose`, ...).
+- **API operations** (creating, starting, exec-ing, and listing containers) go through the
+  Docker SDK. When Podman is selected, `devgo` automatically points the SDK at Podman's
+  API socket if `DOCKER_HOST` is not already set, checking `CONTAINER_HOST`, the rootless
+  socket (`$XDG_RUNTIME_DIR/podman/podman.sock` or `/run/user/<uid>/podman/podman.sock`),
+  and the rootful socket (`/run/podman/podman.sock`).
+
+### Enabling the Podman socket
+
+The Podman API service must be running for the API operations to connect. For a rootless
+setup, enable the user socket once:
+
+```bash
+systemctl --user enable --now podman.socket
+```
+
+Or start it on demand:
+
+```bash
+podman system service --time=0 &
+```
+
+If your socket lives elsewhere, point `devgo` at it explicitly with `DOCKER_HOST` (or
+Podman's `CONTAINER_HOST`), which always takes precedence over auto-detection:
+
+```bash
+export DOCKER_HOST="unix:///run/user/$(id -u)/podman/podman.sock"
+devgo --runtime podman up
+```
 
 ## Development
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -73,14 +73,15 @@ func buildDevContainer(devContainer *devcontainer.DevContainer, workspaceDir, de
 
 	buildArgs = append(buildArgs, buildContext)
 
-	cmd := exec.Command("docker", buildArgs...)
+	runtimeBin := containerRuntimeBinary()
+	cmd := exec.Command(runtimeBin, buildArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	debugf("Running: docker %s\n", strings.Join(buildArgs, " "))
+	debugf("Running: %s %s\n", runtimeBin, strings.Join(buildArgs, " "))
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker build failed: %w", err)
+		return fmt.Errorf("%s build failed: %w", runtimeBin, err)
 	}
 
 	debugf("Successfully built image: %s\n", imageTag)
@@ -131,12 +132,13 @@ func determineImageTag(devContainer *devcontainer.DevContainer, workspaceDir str
 func pushImage(imageTag string) error {
 	debugf("Pushing image: %s\n", imageTag)
 
-	cmd := exec.Command("docker", "push", imageTag)
+	runtimeBin := containerRuntimeBinary()
+	cmd := exec.Command(runtimeBin, "push", imageTag)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("docker push failed: %w", err)
+		return fmt.Errorf("%s push failed: %w", runtimeBin, err)
 	}
 
 	debugf("Successfully pushed image: %s\n", imageTag)

--- a/cmd/dotfiles_exec.go
+++ b/cmd/dotfiles_exec.go
@@ -24,7 +24,6 @@ const dotfilesExecExitUnknown = -1
 type dotfilesDockerClient interface {
 	ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
 	ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
-	ContainerExecStart(ctx context.Context, execID string, config container.ExecStartOptions) error
 	ContainerExecInspect(ctx context.Context, execID string) (container.ExecInspect, error)
 }
 
@@ -62,15 +61,15 @@ func (d *dotfilesExecutor) Exec(ctx context.Context, user string, cmd []string) 
 		return "", "", dotfilesExecExitUnknown, fmt.Errorf("failed to create exec: %w", err)
 	}
 
+	// ContainerExecAttach posts to /exec/{id}/start, which both starts the
+	// exec and hijacks the connection. A separate ContainerExecStart would hit
+	// the same endpoint again; Podman rejects that second start with "exec
+	// session state improper", so attach alone is the portable pattern.
 	attach, err := d.cli.ContainerExecAttach(ctx, create.ID, container.ExecAttachOptions{Tty: false})
 	if err != nil {
 		return "", "", dotfilesExecExitUnknown, fmt.Errorf("failed to attach exec: %w", err)
 	}
 	defer attach.Close()
-
-	if err := d.cli.ContainerExecStart(ctx, create.ID, container.ExecStartOptions{}); err != nil {
-		return "", "", dotfilesExecExitUnknown, fmt.Errorf("failed to start exec: %w", err)
-	}
 
 	var stdout, stderr bytes.Buffer
 	if _, copyErr := stdcopy.StdCopy(&stdout, &stderr, attach.Reader); copyErr != nil && !errors.Is(copyErr, io.EOF) {

--- a/cmd/dotfiles_exec_test.go
+++ b/cmd/dotfiles_exec_test.go
@@ -16,7 +16,6 @@ import (
 type mockDotfilesClient struct {
 	createErr   error
 	attachErr   error
-	startErr    error
 	inspectErr  error
 	exitCode    int
 	attachResp  types.HijackedResponse
@@ -36,10 +35,6 @@ func (m *mockDotfilesClient) ContainerExecAttach(_ context.Context, _ string, _ 
 		return types.HijackedResponse{}, m.attachErr
 	}
 	return m.attachResp, nil
-}
-
-func (m *mockDotfilesClient) ContainerExecStart(_ context.Context, _ string, _ container.ExecStartOptions) error {
-	return m.startErr
 }
 
 func (m *mockDotfilesClient) ContainerExecInspect(_ context.Context, _ string) (container.ExecInspect, error) {
@@ -88,21 +83,6 @@ func TestDotfilesExecutor_AttachError_ReturnsExitUnknown(t *testing.T) {
 	_, _, code, err := exec.Exec(context.Background(), "u", []string{"true"})
 	if err == nil {
 		t.Fatalf("expected error from Exec when ExecAttach fails")
-	}
-	if code != dotfilesExecExitUnknown {
-		t.Errorf("expected exit code = %d (unknown), got %d", dotfilesExecExitUnknown, code)
-	}
-}
-
-func TestDotfilesExecutor_StartError_ReturnsExitUnknown(t *testing.T) {
-	mock := &mockDotfilesClient{
-		attachResp: createMockHijackedResponseValid(),
-		startErr:   errors.New("boom"),
-	}
-	exec := newDotfilesExecutor(mock, "container1")
-	_, _, code, err := exec.Exec(context.Background(), "u", []string{"true"})
-	if err == nil {
-		t.Fatalf("expected error from Exec when ExecStart fails")
 	}
 	if code != dotfilesExecExitUnknown {
 		t.Errorf("expected exit code = %d (unknown), got %d", dotfilesExecExitUnknown, code)

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -21,6 +21,9 @@ type DockerExecClient interface {
 	ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error)
 	ContainerInspect(ctx context.Context, containerID string) (types.ContainerJSON, error) //nolint:staticcheck // types.ContainerJSON is deprecated but upgrading requires major refactoring
 	ContainerExecCreate(ctx context.Context, containerID string, config container.ExecOptions) (container.ExecCreateResponse, error)
+	// ContainerExecStart is still used by the interactive shell path
+	// (executeInteractiveShell); executeCommandInContainer relies on
+	// ContainerExecAttach alone to start the exec.
 	ContainerExecStart(ctx context.Context, execID string, config container.ExecStartOptions) error
 	ContainerExecAttach(ctx context.Context, execID string, config container.ExecAttachOptions) (types.HijackedResponse, error)
 	Close() error
@@ -108,6 +111,10 @@ func executeCommandInContainer(ctx context.Context, cli DockerExecClient, contai
 		return fmt.Errorf("failed to create exec instance: %w", err)
 	}
 
+	// ContainerExecAttach posts to /exec/{id}/start, so it both starts the
+	// exec and hijacks the connection for streaming. Do not also call
+	// ContainerExecStart: that hits the same endpoint a second time, which
+	// Docker tolerates but Podman rejects with "exec session state improper".
 	execAttachResp, err := cli.ContainerExecAttach(ctx, execCreateResp.ID, container.ExecAttachOptions{
 		Tty: false,
 	})
@@ -115,12 +122,6 @@ func executeCommandInContainer(ctx context.Context, cli DockerExecClient, contai
 		return fmt.Errorf("failed to attach to exec instance: %w", err)
 	}
 	defer execAttachResp.Close()
-
-	// Start the exec instance
-	err = cli.ContainerExecStart(ctx, execCreateResp.ID, container.ExecStartOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to start exec instance: %w", err)
-	}
 
 	// Demultiplex the output stream (Docker uses multiplexed stdout/stderr)
 	_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, execAttachResp.Reader)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,6 +81,9 @@ func parseAllFlags(args []string) ([]string, error) {
 			noDotfiles = true
 		} else if arg == "--force-dotfiles" {
 			forceDotfiles = true
+		} else if arg == "--runtime" && i+1 < len(args) {
+			runtimeOverride = args[i+1]
+			i++
 		} else if arg == "--shell" && i+1 < len(args) {
 			shellOverride = args[i+1]
 			i++
@@ -115,6 +118,12 @@ func Execute() error {
 	if showVersion {
 		showVersionInfo()
 		return nil
+	}
+
+	// When Podman is selected, make sure the Docker SDK connects to Podman's
+	// API socket before any command constructs a client via client.FromEnv.
+	if isPodman() {
+		ensurePodmanHost()
 	}
 
 	if len(args) == 0 {
@@ -212,6 +221,10 @@ Flags:
         Override container name
   --push
         Publish the built image
+  --runtime string
+        Container runtime to use: "docker" (default) or "podman". Overrides
+        the DEVGO_CONTAINER_RUNTIME environment variable and the
+        containerRuntime setting in the user config.
   --pull
         Force pull image before starting container
   --session string

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -118,6 +118,17 @@ func queryPodmanMachineSocket() string {
 	return strings.TrimSpace(string(out))
 }
 
+// shouldForwardSSHAgent reports whether the host SSH agent socket can be
+// bind-mounted into containers. Podman on macOS and Windows runs containers
+// inside a VM, and a host unix socket cannot cross the VM boundary, so
+// forwarding is disabled there.
+func shouldForwardSSHAgent(runtimeName, goos string) bool {
+	if runtimeName != "podman" {
+		return true
+	}
+	return goos != "darwin" && goos != "windows"
+}
+
 // podmanSocketCandidates lists the well-known locations of the Podman API
 // socket, most specific first: the rootless per-user socket (via
 // XDG_RUNTIME_DIR or the numeric uid) followed by the rootful system socket.

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -73,10 +74,7 @@ func ensurePodmanHost() {
 		}
 		return
 	}
-	for _, sock := range podmanSocketCandidates() {
-		if _, err := os.Stat(sock); err != nil {
-			continue
-		}
+	if sock := findPodmanSocket(podmanSocketCandidates(), queryPodmanMachineSocket); sock != "" {
 		host := "unix://" + sock
 		if err := os.Setenv("DOCKER_HOST", host); err != nil {
 			warnf("failed to set DOCKER_HOST for Podman: %v", err)
@@ -87,6 +85,37 @@ func ensurePodmanHost() {
 	}
 	debugln("No Podman API socket found; relying on the SDK default connection." +
 		" Run 'podman system service' or 'systemctl --user start podman.socket' if connections fail.")
+}
+
+// findPodmanSocket returns the first existing socket among the well-known
+// candidate paths, falling back to the socket reported by queryMachineSocket.
+// The fallback covers macOS and Windows, where Podman runs inside a VM and
+// exposes its API through a per-machine socket outside the candidate paths.
+func findPodmanSocket(candidates []string, queryMachineSocket func() string) string {
+	for _, sock := range candidates {
+		if _, err := os.Stat(sock); err == nil {
+			return sock
+		}
+	}
+	if sock := queryMachineSocket(); sock != "" {
+		if _, err := os.Stat(sock); err == nil {
+			return sock
+		}
+	}
+	return ""
+}
+
+// queryPodmanMachineSocket asks the podman CLI for the host-side API socket of
+// the default podman machine. The socket lives under an unpredictable per-user
+// temporary directory, so it cannot be probed as a static candidate path. It
+// returns an empty string when no machine is configured or podman is missing.
+func queryPodmanMachineSocket() string {
+	out, err := exec.Command(containerRuntimeBinary(), "machine", "inspect",
+		"--format", "{{.ConnectionInfo.PodmanSocket.Path}}").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // podmanSocketCandidates lists the well-known locations of the Podman API

--- a/cmd/runtime.go
+++ b/cmd/runtime.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/garaemon/devgo/pkg/config"
+)
+
+// runtimeOverride is populated by the global --runtime flag. When empty the
+// runtime is resolved from the environment and user config instead.
+var runtimeOverride string
+
+// selectRuntime applies devgo's runtime-selection precedence to explicit
+// inputs. It is kept separate from resolveContainerRuntime so the precedence
+// rules can be unit-tested without touching global flag state or the
+// filesystem. Precedence, highest first: flag, environment variable, user
+// config, then the "docker" default.
+func selectRuntime(flagVal, envVal, configVal string) string {
+	raw := flagVal
+	if raw == "" {
+		raw = envVal
+	}
+	if raw == "" {
+		raw = configVal
+	}
+	raw = strings.ToLower(strings.TrimSpace(raw))
+	if raw == "" {
+		return "docker"
+	}
+	return raw
+}
+
+// resolveContainerRuntime returns the container runtime devgo should drive,
+// e.g. "docker" or "podman". It reads, in order of decreasing precedence, the
+// --runtime flag, the DEVGO_CONTAINER_RUNTIME environment variable, and the
+// containerRuntime field in ~/.config/devgo/config.json.
+func resolveContainerRuntime() string {
+	configVal := ""
+	if cfg, err := config.LoadUserConfig(); err == nil && cfg != nil {
+		configVal = cfg.ContainerRuntime
+	}
+	return selectRuntime(runtimeOverride, os.Getenv("DEVGO_CONTAINER_RUNTIME"), configVal)
+}
+
+// containerRuntimeBinary returns the executable name used for CLI-level
+// operations (image build/push and compose). It is the resolved runtime name,
+// so a value of "podman" runs the podman binary while "docker" runs docker.
+func containerRuntimeBinary() string {
+	return resolveContainerRuntime()
+}
+
+// isPodman reports whether the selected runtime is Podman.
+func isPodman() bool {
+	return resolveContainerRuntime() == "podman"
+}
+
+// ensurePodmanHost points the Docker SDK at Podman's API socket when the user
+// selected the podman runtime but hasn't told the SDK where to connect. Podman
+// exposes a Docker-compatible API over this socket, so once DOCKER_HOST refers
+// to it the existing client.FromEnv calls work against Podman unchanged. An
+// explicit DOCKER_HOST (or Podman's own CONTAINER_HOST) is always respected and
+// left untouched.
+func ensurePodmanHost() {
+	if os.Getenv("DOCKER_HOST") != "" {
+		return
+	}
+	if host := os.Getenv("CONTAINER_HOST"); host != "" {
+		if err := os.Setenv("DOCKER_HOST", host); err != nil {
+			warnf("failed to set DOCKER_HOST from CONTAINER_HOST: %v", err)
+		}
+		return
+	}
+	for _, sock := range podmanSocketCandidates() {
+		if _, err := os.Stat(sock); err != nil {
+			continue
+		}
+		host := "unix://" + sock
+		if err := os.Setenv("DOCKER_HOST", host); err != nil {
+			warnf("failed to set DOCKER_HOST for Podman: %v", err)
+			return
+		}
+		debugf("Using Podman socket %s\n", sock)
+		return
+	}
+	debugln("No Podman API socket found; relying on the SDK default connection." +
+		" Run 'podman system service' or 'systemctl --user start podman.socket' if connections fail.")
+}
+
+// podmanSocketCandidates lists the well-known locations of the Podman API
+// socket, most specific first: the rootless per-user socket (via
+// XDG_RUNTIME_DIR or the numeric uid) followed by the rootful system socket.
+func podmanSocketCandidates() []string {
+	var candidates []string
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		candidates = append(candidates, filepath.Join(xdg, "podman", "podman.sock"))
+	}
+	if uid := os.Getuid(); uid > 0 {
+		candidates = append(candidates, fmt.Sprintf("/run/user/%d/podman/podman.sock", uid))
+	}
+	candidates = append(candidates, "/run/podman/podman.sock")
+	return candidates
+}

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -148,6 +148,54 @@ func TestEnsurePodmanHost_UsesContainerHost(t *testing.T) {
 	}
 }
 
+func TestFindPodmanSocket_FallsBackToMachineSocket(t *testing.T) {
+	// On macOS the Podman API socket lives under the podman-machine state
+	// directory, not under the Linux-style candidate paths. devgo must fall
+	// back to the socket path reported by the podman CLI in that case.
+	machineSock := filepath.Join(t.TempDir(), "podman-machine-default-api.sock")
+	if err := os.WriteFile(machineSock, []byte{}, 0o600); err != nil {
+		t.Fatalf("failed to create fake machine socket: %v", err)
+	}
+	missingCandidates := []string{
+		filepath.Join(t.TempDir(), "missing", "podman.sock"),
+	}
+
+	got := findPodmanSocket(missingCandidates, func() string { return machineSock })
+
+	if got != machineSock {
+		t.Errorf("findPodmanSocket() = %q, want %q", got, machineSock)
+	}
+}
+
+func TestFindPodmanSocket_PrefersCandidateOverMachineSocket(t *testing.T) {
+	candidateSock := filepath.Join(t.TempDir(), "podman.sock")
+	if err := os.WriteFile(candidateSock, []byte{}, 0o600); err != nil {
+		t.Fatalf("failed to create fake candidate socket: %v", err)
+	}
+
+	got := findPodmanSocket([]string{candidateSock}, func() string {
+		t.Error("queryMachineSocket should not be called when a candidate exists")
+		return ""
+	})
+
+	if got != candidateSock {
+		t.Errorf("findPodmanSocket() = %q, want %q", got, candidateSock)
+	}
+}
+
+func TestFindPodmanSocket_ReturnsEmptyWhenNothingExists(t *testing.T) {
+	missingCandidates := []string{
+		filepath.Join(t.TempDir(), "missing", "podman.sock"),
+	}
+	missingMachineSock := filepath.Join(t.TempDir(), "missing-machine.sock")
+
+	got := findPodmanSocket(missingCandidates, func() string { return missingMachineSock })
+
+	if got != "" {
+		t.Errorf("findPodmanSocket() = %q, want empty string", got)
+	}
+}
+
 func TestEnsurePodmanHost_DetectsSocketFile(t *testing.T) {
 	t.Setenv("DOCKER_HOST", "")
 	t.Setenv("CONTAINER_HOST", "")

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -196,6 +196,55 @@ func TestFindPodmanSocket_ReturnsEmptyWhenNothingExists(t *testing.T) {
 	}
 }
 
+func TestShouldForwardSSHAgent(t *testing.T) {
+	tests := []struct {
+		name        string
+		runtimeName string
+		goos        string
+		want        bool
+	}{
+		{
+			name:        "docker on linux forwards",
+			runtimeName: "docker",
+			goos:        "linux",
+			want:        true,
+		},
+		{
+			name:        "docker on darwin forwards",
+			runtimeName: "docker",
+			goos:        "darwin",
+			want:        true,
+		},
+		{
+			name:        "podman on linux forwards",
+			runtimeName: "podman",
+			goos:        "linux",
+			want:        true,
+		},
+		{
+			name:        "podman on darwin skips because of the VM boundary",
+			runtimeName: "podman",
+			goos:        "darwin",
+			want:        false,
+		},
+		{
+			name:        "podman on windows skips because of the VM boundary",
+			runtimeName: "podman",
+			goos:        "windows",
+			want:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldForwardSSHAgent(tt.runtimeName, tt.goos); got != tt.want {
+				t.Errorf("shouldForwardSSHAgent(%q, %q) = %v, want %v",
+					tt.runtimeName, tt.goos, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestEnsurePodmanHost_DetectsSocketFile(t *testing.T) {
 	t.Setenv("DOCKER_HOST", "")
 	t.Setenv("CONTAINER_HOST", "")

--- a/cmd/runtime_test.go
+++ b/cmd/runtime_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSelectRuntime(t *testing.T) {
+	tests := []struct {
+		name      string
+		flagVal   string
+		envVal    string
+		configVal string
+		want      string
+	}{
+		{
+			name: "defaults to docker when nothing is set",
+			want: "docker",
+		},
+		{
+			name:    "flag selects podman",
+			flagVal: "podman",
+			want:    "podman",
+		},
+		{
+			name:      "flag beats env and config",
+			flagVal:   "podman",
+			envVal:    "docker",
+			configVal: "docker",
+			want:      "podman",
+		},
+		{
+			name:      "env beats config",
+			envVal:    "podman",
+			configVal: "docker",
+			want:      "podman",
+		},
+		{
+			name:      "config used when flag and env empty",
+			configVal: "podman",
+			want:      "podman",
+		},
+		{
+			name:    "value is lowercased and trimmed",
+			flagVal: "  PodMan  ",
+			want:    "podman",
+		},
+		{
+			name:    "unknown runtime passes through for custom binaries",
+			flagVal: "nerdctl",
+			want:    "nerdctl",
+		},
+		{
+			name:    "whitespace-only value falls back to default",
+			flagVal: "   ",
+			want:    "docker",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectRuntime(tt.flagVal, tt.envVal, tt.configVal); got != tt.want {
+				t.Errorf("selectRuntime(%q, %q, %q) = %q, want %q",
+					tt.flagVal, tt.envVal, tt.configVal, got, tt.want)
+			}
+		})
+	}
+}
+
+// withCleanRuntimeEnv isolates the runtime-selection inputs so tests do not
+// leak into one another or depend on the developer's environment.
+func withCleanRuntimeEnv(t *testing.T) {
+	t.Helper()
+	prev := runtimeOverride
+	runtimeOverride = ""
+	t.Cleanup(func() { runtimeOverride = prev })
+
+	// Pin the config lookup at an empty temp dir so no real user config is read.
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("DEVGO_CONTAINER_RUNTIME", "")
+}
+
+func TestResolveContainerRuntime_DefaultDocker(t *testing.T) {
+	withCleanRuntimeEnv(t)
+
+	if got := resolveContainerRuntime(); got != "docker" {
+		t.Errorf("resolveContainerRuntime() = %q, want %q", got, "docker")
+	}
+	if isPodman() {
+		t.Errorf("isPodman() = true, want false for default runtime")
+	}
+}
+
+func TestResolveContainerRuntime_EnvSelectsPodman(t *testing.T) {
+	withCleanRuntimeEnv(t)
+	t.Setenv("DEVGO_CONTAINER_RUNTIME", "podman")
+
+	if got := resolveContainerRuntime(); got != "podman" {
+		t.Errorf("resolveContainerRuntime() = %q, want %q", got, "podman")
+	}
+	if !isPodman() {
+		t.Errorf("isPodman() = false, want true")
+	}
+}
+
+func TestResolveContainerRuntime_FlagOverridesEnv(t *testing.T) {
+	withCleanRuntimeEnv(t)
+	t.Setenv("DEVGO_CONTAINER_RUNTIME", "docker")
+	runtimeOverride = "podman"
+
+	if got := resolveContainerRuntime(); got != "podman" {
+		t.Errorf("resolveContainerRuntime() = %q, want %q", got, "podman")
+	}
+}
+
+func TestResolveContainerRuntime_UserConfig(t *testing.T) {
+	withCleanRuntimeEnv(t)
+	dir := filepath.Join(t.TempDir(), "devgo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"),
+		[]byte(`{"containerRuntime": "podman"}`), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", filepath.Dir(dir))
+
+	if got := resolveContainerRuntime(); got != "podman" {
+		t.Errorf("resolveContainerRuntime() = %q, want %q", got, "podman")
+	}
+}
+
+func TestEnsurePodmanHost_RespectsExistingDockerHost(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "tcp://example:2375")
+	ensurePodmanHost()
+	if got := os.Getenv("DOCKER_HOST"); got != "tcp://example:2375" {
+		t.Errorf("DOCKER_HOST = %q, want it left unchanged", got)
+	}
+}
+
+func TestEnsurePodmanHost_UsesContainerHost(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("CONTAINER_HOST", "unix:///tmp/custom-podman.sock")
+	ensurePodmanHost()
+	if got := os.Getenv("DOCKER_HOST"); got != "unix:///tmp/custom-podman.sock" {
+		t.Errorf("DOCKER_HOST = %q, want it derived from CONTAINER_HOST", got)
+	}
+}
+
+func TestEnsurePodmanHost_DetectsSocketFile(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("CONTAINER_HOST", "")
+
+	runtimeDir := t.TempDir()
+	sockDir := filepath.Join(runtimeDir, "podman")
+	if err := os.MkdirAll(sockDir, 0o755); err != nil {
+		t.Fatalf("failed to create socket dir: %v", err)
+	}
+	sockPath := filepath.Join(sockDir, "podman.sock")
+	if err := os.WriteFile(sockPath, []byte{}, 0o600); err != nil {
+		t.Fatalf("failed to create fake socket: %v", err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
+
+	ensurePodmanHost()
+
+	want := "unix://" + sockPath
+	if got := os.Getenv("DOCKER_HOST"); got != want {
+		t.Errorf("DOCKER_HOST = %q, want %q", got, want)
+	}
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -753,17 +753,17 @@ func startContainerWithDockerCompose(ctx context.Context, devContainer *devconta
 
 	// Start docker compose services
 	upArgs := append(composeArgs, append([]string{"up", "-d"}, runServices...)...)
-	upCmd := exec.Command("docker", append([]string{"compose"}, upArgs...)...)
+	upCmd := exec.Command(containerRuntimeBinary(), append([]string{"compose"}, upArgs...)...)
 	upCmd.Dir = workspaceDir
 	upCmd.Stdout = os.Stdout
 	upCmd.Stderr = os.Stderr
 
-	debugf("Starting docker compose services: %s\n", strings.Join(runServices, ", "))
+	debugf("Starting compose services: %s\n", strings.Join(runServices, ", "))
 	if err := upCmd.Run(); err != nil {
-		return fmt.Errorf("failed to start docker compose services: %w", err)
+		return fmt.Errorf("failed to start compose services: %w", err)
 	}
 
-	debugf("Docker compose services started successfully\n")
+	debugf("Compose services started successfully\n")
 	return executeLifecycleCommands(ctx, devContainer, containerName, workspaceDir)
 }
 
@@ -799,7 +799,7 @@ func getComposeServiceEnv(workspaceDir string, composeFiles []string, service st
 	}
 	args = append(args, "config", "--format", "json")
 
-	cmd := exec.Command("docker", append([]string{"compose"}, args...)...)
+	cmd := exec.Command(containerRuntimeBinary(), append([]string{"compose"}, args...)...)
 	cmd.Dir = workspaceDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -451,7 +451,9 @@ func (r *realDockerClient) CreateAndStartContainer(ctx context.Context, args Doc
 	binds := []string{fmt.Sprintf("%s:%s", args.WorkspaceDir, args.WorkspaceFolder)}
 
 	// Add SSH agent forwarding if available
-	if sshagent.IsAvailable() {
+	if !shouldForwardSSHAgent(resolveContainerRuntime(), runtime.GOOS) {
+		debugln("Skipping SSH agent forwarding: host sockets cannot cross the Podman VM boundary")
+	} else if sshagent.IsAvailable() {
 		hostSocket, err := sshagent.GetHostSocket()
 		if err == nil {
 			mount := sshagent.CreateMount(hostSocket)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,6 +12,9 @@ type Config struct {
 	DockerHost      string
 	ContainerPrefix string
 	WorkspaceMount  string
+	// ContainerRuntime selects the container engine devgo drives ("docker"
+	// or "podman"). Empty means the default ("docker").
+	ContainerRuntime string
 }
 
 // DotfilesConfig holds the persistent dotfiles preferences loaded from
@@ -33,13 +36,18 @@ type UserConfig struct {
 	// Shell overrides the program devgo invokes for `devgo shell`. When
 	// empty, devgo falls back to /bin/bash. Always launched with -i.
 	Shell string `json:"shell,omitempty"`
+	// ContainerRuntime selects the container engine devgo drives ("docker"
+	// or "podman"). Empty means the default ("docker"). The --runtime flag
+	// and DEVGO_CONTAINER_RUNTIME environment variable override this value.
+	ContainerRuntime string `json:"containerRuntime,omitempty"`
 }
 
 func Load() (*Config, error) {
 	cfg := &Config{
-		DockerHost:      getEnv("DOCKER_HOST", ""),
-		ContainerPrefix: getEnv("DEVGO_CONTAINER_PREFIX", "devgo-"),
-		WorkspaceMount:  getEnv("DEVGO_WORKSPACE_MOUNT", "/workspace"),
+		DockerHost:       getEnv("DOCKER_HOST", ""),
+		ContainerPrefix:  getEnv("DEVGO_CONTAINER_PREFIX", "devgo-"),
+		WorkspaceMount:   getEnv("DEVGO_WORKSPACE_MOUNT", "/workspace"),
+		ContainerRuntime: getEnv("DEVGO_CONTAINER_RUNTIME", ""),
 	}
 
 	return cfg, nil

--- a/test/integration/docker_compose_test.go
+++ b/test/integration/docker_compose_test.go
@@ -317,7 +317,7 @@ services:
 
 // isDockerComposeAvailable checks if Docker Compose is available
 func isDockerComposeAvailable() bool {
-	cmd := exec.Command("docker", "compose", "version")
+	cmd := exec.Command(containerRuntime(), "compose", "version")
 	return cmd.Run() == nil
 }
 
@@ -326,7 +326,7 @@ func cleanupDockerCompose(t *testing.T, projectDir string) {
 	t.Helper()
 
 	// Stop and remove containers using docker compose down
-	cmd := exec.Command("docker", "compose", "down", "--remove-orphans")
+	cmd := exec.Command(containerRuntime(), "compose", "down", "--remove-orphans")
 	cmd.Dir = projectDir
 	if err := cmd.Run(); err != nil {
 		t.Logf("Warning: failed to run docker compose down: %v", err)

--- a/test/integration/runtime_helpers_test.go
+++ b/test/integration/runtime_helpers_test.go
@@ -1,0 +1,19 @@
+package integration
+
+import (
+	"os"
+	"strings"
+)
+
+// containerRuntime returns the container runtime binary the integration tests
+// should drive for their own setup, verification, and cleanup commands. It
+// mirrors how devgo itself resolves the runtime from DEVGO_CONTAINER_RUNTIME,
+// so a single environment variable keeps the devgo binary under test and the
+// tests' helper commands (ps, inspect, exec, compose, ...) pointed at the same
+// engine. The default is "docker".
+func containerRuntime() string {
+	if r := strings.TrimSpace(os.Getenv("DEVGO_CONTAINER_RUNTIME")); r != "" {
+		return strings.ToLower(r)
+	}
+	return "docker"
+}

--- a/test/integration/up_test.go
+++ b/test/integration/up_test.go
@@ -120,7 +120,7 @@ func TestUpCommandIntegration(t *testing.T) {
 
 			if !isContainerRunning(t, containerName) {
 				// List all containers for debugging
-				listCmd := exec.Command("docker", "ps", "-a")
+				listCmd := exec.Command(containerRuntime(), "ps", "-a")
 				listOutput, _ := listCmd.Output()
 				t.Logf("All containers: %s", string(listOutput))
 
@@ -219,7 +219,7 @@ func buildExpectedContainerName(workspaceDir string) string {
 }
 
 func isDockerAvailable() bool {
-	execCmd := exec.Command("docker", "version")
+	execCmd := exec.Command(containerRuntime(), "version")
 	return execCmd.Run() == nil
 }
 
@@ -274,7 +274,7 @@ func setupDevcontainer(t *testing.T, tempDir, containerName string) {
 func isContainerRunning(t *testing.T, containerName string) bool {
 	t.Helper()
 
-	cmd := exec.Command("docker", "ps", "--filter", fmt.Sprintf("name=%s", containerName), "--format", "{{.Names}}")
+	cmd := exec.Command(containerRuntime(), "ps", "--filter", fmt.Sprintf("name=%s", containerName), "--format", "{{.Names}}")
 	output, err := cmd.Output()
 	if err != nil {
 		t.Logf("Failed to check if container is running: %v", err)
@@ -288,7 +288,7 @@ func verifyContainerProperties(t *testing.T, containerName, workspaceDir string)
 	t.Helper()
 
 	// Check if container has the correct labels
-	cmd := exec.Command("docker", "inspect", containerName, "--format", "{{.Config.Labels}}")
+	cmd := exec.Command(containerRuntime(), "inspect", containerName, "--format", "{{.Config.Labels}}")
 	output, err := cmd.Output()
 	if err != nil {
 		t.Errorf("Failed to inspect container: %v", err)
@@ -301,7 +301,7 @@ func verifyContainerProperties(t *testing.T, containerName, workspaceDir string)
 	}
 
 	// Check if workspace is mounted correctly
-	cmd = exec.Command("docker", "inspect", containerName, "--format", "{{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}")
+	cmd = exec.Command(containerRuntime(), "inspect", containerName, "--format", "{{range .Mounts}}{{.Source}}:{{.Destination}} {{end}}")
 	output, err = cmd.Output()
 	if err != nil {
 		t.Errorf("Failed to inspect container mounts: %v", err)
@@ -318,7 +318,7 @@ func verifyContainerProperties(t *testing.T, containerName, workspaceDir string)
 func stopContainer(t *testing.T, containerName string) {
 	t.Helper()
 
-	cmd := exec.Command("docker", "stop", containerName)
+	cmd := exec.Command(containerRuntime(), "stop", containerName)
 	if err := cmd.Run(); err != nil {
 		t.Logf("Failed to stop container %s: %v", containerName, err)
 	}
@@ -329,7 +329,7 @@ func cleanupContainer(t *testing.T, containerName string) {
 
 	// Force stop and remove container
 	// Use -f flag to force removal even if container is running
-	removeCmd := exec.Command("docker", "rm", "-f", containerName)
+	removeCmd := exec.Command(containerRuntime(), "rm", "-f", containerName)
 	removeCmd.Run() // Ignore errors - container might not exist
 
 	// Also cleanup any containers with matching prefix (e.g., docker compose containers)
@@ -347,7 +347,7 @@ func cleanupContainer(t *testing.T, containerName string) {
 		}
 
 		for _, cn := range composeContainers {
-			cmd := exec.Command("docker", "rm", "-f", cn)
+			cmd := exec.Command(containerRuntime(), "rm", "-f", cn)
 			cmd.Run() // Ignore errors
 		}
 	}
@@ -591,7 +591,7 @@ func containerPathExists(t *testing.T, containerName, path string, isDir bool) b
 		testCmd = []string{"test", "-f", path}
 	}
 
-	cmd := exec.Command("docker", "exec", containerName)
+	cmd := exec.Command(containerRuntime(), "exec", containerName)
 	cmd.Args = append(cmd.Args, testCmd...)
 
 	err := cmd.Run()
@@ -601,7 +601,7 @@ func containerPathExists(t *testing.T, containerName, path string, isDir bool) b
 func runCommandInContainer(t *testing.T, containerName string, command []string) string {
 	t.Helper()
 
-	cmd := exec.Command("docker", "exec", containerName)
+	cmd := exec.Command(containerRuntime(), "exec", containerName)
 	cmd.Args = append(cmd.Args, command...)
 
 	output, err := cmd.Output()
@@ -619,7 +619,7 @@ func cleanupContainerFiles(t *testing.T, containerName, workspaceDir string) {
 	// Only cleanup if container exists and is running
 	if !isContainerRunning(t, containerName) {
 		// Check if container exists but is stopped
-		cmd := exec.Command("docker", "ps", "-a", "--filter", fmt.Sprintf("name=%s", containerName), "--format", "{{.Names}}")
+		cmd := exec.Command(containerRuntime(), "ps", "-a", "--filter", fmt.Sprintf("name=%s", containerName), "--format", "{{.Names}}")
 		output, err := cmd.Output()
 		if err != nil || !strings.Contains(string(output), containerName) {
 			return // Container doesn't exist
@@ -636,7 +636,7 @@ func cleanupContainerFiles(t *testing.T, containerName, workspaceDir string) {
 	}
 
 	for _, cmdArgs := range cleanupCommands {
-		cmd := exec.Command("docker", "exec", containerName)
+		cmd := exec.Command(containerRuntime(), "exec", containerName)
 		cmd.Args = append(cmd.Args, cmdArgs...)
 		cmd.Run() // Ignore errors - files might not exist
 	}
@@ -821,7 +821,7 @@ func TestUpdateRemoteUserUIDIntegration(t *testing.T) {
 			// Verify that files created in workspace have correct ownership
 			if tt.expectHostUID && tt.targetUser != "root" {
 				// Create a test file in the container
-				createCmd := exec.Command("docker", "exec", "-u", tt.targetUser, containerName, "touch", "/workspace/test-ownership.txt")
+				createCmd := exec.Command(containerRuntime(), "exec", "-u", tt.targetUser, containerName, "touch", "/workspace/test-ownership.txt")
 				if err := createCmd.Run(); err != nil {
 					t.Logf("Failed to create test file: %v", err)
 				} else {
@@ -843,7 +843,7 @@ func TestUpdateRemoteUserUIDIntegration(t *testing.T) {
 func getContainerUserUID(t *testing.T, containerName, username string) int {
 	t.Helper()
 
-	cmd := exec.Command("docker", "exec", containerName, "id", "-u", username)
+	cmd := exec.Command(containerRuntime(), "exec", containerName, "id", "-u", username)
 	output, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("Failed to get UID for user %s: %v", username, err)
@@ -862,7 +862,7 @@ func getContainerUserUID(t *testing.T, containerName, username string) int {
 func getContainerUserGID(t *testing.T, containerName, username string) int {
 	t.Helper()
 
-	cmd := exec.Command("docker", "exec", containerName, "id", "-g", username)
+	cmd := exec.Command(containerRuntime(), "exec", containerName, "id", "-g", username)
 	output, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("Failed to get GID for user %s: %v", username, err)


### PR DESCRIPTION
## Summary

This PR adds support for using Podman as an alternative container runtime alongside Docker. Users can now select their preferred runtime via command-line flag, environment variable, or user configuration file, with devgo defaulting to Docker for backward compatibility.

## Key Changes

- **Runtime selection system** (`cmd/runtime.go`): Implements precedence-based runtime resolution (flag > environment > config > default) with the `selectRuntime()`, `resolveContainerRuntime()`, and `isPodman()` functions
- **Podman socket detection** (`cmd/runtime.go`): Automatically configures the Docker SDK to connect to Podman's API socket when Podman is selected, checking `DOCKER_HOST`, `CONTAINER_HOST`, and well-known socket locations (`$XDG_RUNTIME_DIR/podman/podman.sock`, `/run/user/<uid>/podman/podman.sock`, `/run/podman/podman.sock`)
- **CLI flag support** (`cmd/root.go`): Added `--runtime` flag to select container runtime at invocation time
- **Binary selection** (`cmd/build.go`, `cmd/up.go`): Updated build and compose operations to invoke the selected runtime binary (`docker` or `podman`) instead of hardcoded `docker`
- **Configuration support** (`pkg/config/config.go`): Added `ContainerRuntime` field to user config (`~/.config/devgo/config.json`) for persistent runtime selection
- **Comprehensive testing** (`cmd/runtime_test.go`): Added unit tests covering runtime selection precedence, socket detection, and environment isolation
- **Integration test updates** (`test/integration/`): Modified integration tests to use the selected runtime via new `containerRuntime()` helper function, enabling testing against both Docker and Podman
- **CI/CD enhancement** (`.github/workflows/test.yml`): Added `integration-podman` job to run the full integration test suite against Podman with automatic socket setup
- **Documentation** (`README.md`): Added comprehensive "Container Runtime (Docker / Podman)" section explaining runtime selection, socket configuration, and usage examples

## macOS and Windows Fixes for Podman Machine

Podman on macOS and Windows runs containers inside a VM (`podman machine`), which broke two paths that worked on Linux:

- **Machine socket fallback** (`cmd/runtime.go`): The API socket lives under an unpredictable per-user temporary directory (e.g. `/var/folders/.../T/podman/podman-machine-default-api.sock`), so the Linux-style candidate paths never matched and devgo fell back to `docker.sock` (`Cannot connect to the Docker daemon`). When no candidate path exists, devgo now asks the podman CLI for the machine socket via `podman machine inspect`.
- **SSH agent forwarding skip** (`cmd/up.go`): devgo bind-mounts the host `SSH_AUTH_SOCK` socket, but a host unix socket cannot cross the VM boundary, and the mount fails outright for sockets under TCC-protected directories (e.g. the 1Password agent socket). `devgo up` now skips the SSH agent mount for Podman on macOS and Windows instead of failing.

Both fixes were verified end-to-end on macOS with a real podman machine (`devgo up` / `exec` / `down`).

## Implementation Details

- Runtime selection follows a clear precedence order: CLI flag overrides environment variable, which overrides config file, which overrides the "docker" default
- The `ensurePodmanHost()` function gracefully handles missing sockets and respects explicit `DOCKER_HOST` configuration
- All hardcoded `docker` binary invocations in build and compose operations now use `containerRuntimeBinary()` to support both runtimes
- Integration tests can be run against either runtime by setting `DEVGO_CONTAINER_RUNTIME=podman`, with the CI pipeline validating both scenarios
- Backward compatible: existing users see no changes; Podman support is opt-in via flag, environment variable, or config file

https://claude.ai/code/session_012bJwWm99U3YscmKvZZbx6s

🤖 Generated with [Claude Code](https://claude.com/claude-code)