### PR TITLE
Use --workspace-folder for devcontainer.json discovery

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -280,12 +280,12 @@ func findDevcontainerConfig(configPath string) (string, error) {
 		return configPath, nil
 	}
 
-	cwd, err := os.Getwd()
+	searchRoot, err := determineConfigSearchRoot()
 	if err != nil {
 		return "", err
 	}
 
-	for dir := cwd; dir != "/"; dir = filepath.Dir(dir) {
+	for dir := searchRoot; dir != "/"; dir = filepath.Dir(dir) {
 		debugf("Checking directory: %s\n", dir)
 
 		configFile := filepath.Join(dir, ".devcontainer", "devcontainer.json")
@@ -300,6 +300,17 @@ func findDevcontainerConfig(configPath string) (string, error) {
 	}
 
 	return "", fmt.Errorf("no devcontainer.json found in current directory or parent directories")
+}
+
+// determineConfigSearchRoot returns the directory where devcontainer.json
+// discovery starts. The --workspace-folder flag takes precedence over the
+// current working directory so that commands operate on the requested
+// workspace regardless of where devgo is invoked from.
+func determineConfigSearchRoot() (string, error) {
+	if workspaceFolder != "" {
+		return filepath.Abs(workspaceFolder)
+	}
+	return os.Getwd()
 }
 
 func determineWorkspaceFolder(devcontainerPath string) string {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -565,5 +566,86 @@ func TestExecute_Help(t *testing.T) {
 	// Verify that usage was printed to stderr
 	if !strings.Contains(stderrOutput, "devgo - Run commands in a devcontainer") {
 		t.Errorf("stderr should contain usage help, got: %s", stderrOutput)
+	}
+}
+
+func TestFindDevcontainerConfigUsesWorkspaceFolder(t *testing.T) {
+	workspaceDir := t.TempDir()
+	devcontainerDir := workspaceDir + "/.devcontainer"
+	if err := os.Mkdir(devcontainerDir, 0o755); err != nil {
+		t.Fatalf("failed to create .devcontainer dir: %v", err)
+	}
+	expectedConfig := devcontainerDir + "/devcontainer.json"
+	if err := os.WriteFile(expectedConfig, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to write devcontainer.json: %v", err)
+	}
+
+	// Run from a directory that has no devcontainer.json so discovery
+	// must rely on the --workspace-folder value, not the cwd.
+	unrelatedDir := t.TempDir()
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	if err := os.Chdir(unrelatedDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Errorf("failed to restore cwd: %v", err)
+		}
+	}()
+
+	originalWorkspaceFolder := workspaceFolder
+	workspaceFolder = workspaceDir
+	defer func() { workspaceFolder = originalWorkspaceFolder }()
+
+	result, err := findDevcontainerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != expectedConfig {
+		t.Errorf("findDevcontainerConfig() = %q, want %q", result, expectedConfig)
+	}
+}
+
+func TestFindDevcontainerConfigFallsBackToCwd(t *testing.T) {
+	workspaceDir := t.TempDir()
+	devcontainerDir := workspaceDir + "/.devcontainer"
+	if err := os.Mkdir(devcontainerDir, 0o755); err != nil {
+		t.Fatalf("failed to create .devcontainer dir: %v", err)
+	}
+	expectedConfig := devcontainerDir + "/devcontainer.json"
+	if err := os.WriteFile(expectedConfig, []byte("{}"), 0o644); err != nil {
+		t.Fatalf("failed to write devcontainer.json: %v", err)
+	}
+
+	originalCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	if err := os.Chdir(workspaceDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(originalCwd); err != nil {
+			t.Errorf("failed to restore cwd: %v", err)
+		}
+	}()
+
+	originalWorkspaceFolder := workspaceFolder
+	workspaceFolder = ""
+	defer func() { workspaceFolder = originalWorkspaceFolder }()
+
+	result, err := findDevcontainerConfig("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Resolve symlinks because t.TempDir may live under a symlinked path
+	// (e.g. /tmp -> /private/tmp) and os.Getwd returns the resolved path.
+	resolvedResult, _ := filepath.EvalSymlinks(result)
+	resolvedExpected, _ := filepath.EvalSymlinks(expectedConfig)
+	if resolvedResult != resolvedExpected {
+		t.Errorf("findDevcontainerConfig() = %q, want %q", resolvedResult, resolvedExpected)
 	}
 }


### PR DESCRIPTION
## Summary

`devgo up --workspace-folder <path>` ignored the flag when discovering `devcontainer.json`. Discovery always started from the current working directory, so devgo could silently start a container from the wrong project's configuration while labeling it with the requested workspace path.

This PR starts the discovery from the `--workspace-folder` value when it is set, and falls back to the cwd otherwise.

## Changes

- Add `determineConfigSearchRoot` that prefers `--workspace-folder` over the cwd.
- Use it in `findDevcontainerConfig`.

## Test plan

- New unit test `TestFindDevcontainerConfigUsesWorkspaceFolder` reproduces the bug (fails without the fix).
- New unit test `TestFindDevcontainerConfigFallsBackToCwd` covers the existing behavior.
- `make test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyCNS4VUn2VfGwvYyhpzfc