### PR TITLE
Support string format for mounts in devcontainer.json

### DIFF
--- a/pkg/devcontainer/devcontainer.go
+++ b/pkg/devcontainer/devcontainer.go
@@ -1,10 +1,12 @@
 package devcontainer
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/titanous/json5"
 )
@@ -32,10 +34,67 @@ const (
 	WaitForPostStartCommand     = "postStartCommand"
 )
 
+// Mount represents an entry of the "mounts" field. The devcontainer spec
+// allows both an object form ({"type": ..., "source": ..., "target": ...})
+// and a Docker CLI style string form ("source=...,target=...,type=...").
 type Mount struct {
 	Type   string `json:"type,omitempty"`
 	Source string `json:"source,omitempty"`
 	Target string `json:"target,omitempty"`
+}
+
+// UnmarshalJSON accepts both the object form and the string form of a mount.
+func (m *Mount) UnmarshalJSON(data []byte) error {
+	var stringForm string
+	if err := json.Unmarshal(data, &stringForm); err == nil {
+		parsed, parseErr := parseMountString(stringForm)
+		if parseErr != nil {
+			return parseErr
+		}
+		*m = parsed
+		return nil
+	}
+
+	// Use a local alias type to avoid infinite recursion into UnmarshalJSON.
+	type mountObject Mount
+	var objectForm mountObject
+	if err := json.Unmarshal(data, &objectForm); err != nil {
+		return err
+	}
+	*m = Mount(objectForm)
+	return nil
+}
+
+// parseMountString parses a Docker CLI style mount string such as
+// "source=/host,target=/container,type=bind". The keys "src" and "dst"
+// (or "destination") are accepted as aliases following Docker's --mount
+// syntax. Unknown keys are ignored so options like "consistency" or
+// "readonly" do not fail the parse.
+func parseMountString(value string) (Mount, error) {
+	var mount Mount
+	for _, field := range strings.Split(value, ",") {
+		if field == "" {
+			continue
+		}
+		keyValue := strings.SplitN(field, "=", 2)
+		if len(keyValue) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(keyValue[0])
+		fieldValue := strings.TrimSpace(keyValue[1])
+		switch key {
+		case "type":
+			mount.Type = fieldValue
+		case "source", "src":
+			mount.Source = fieldValue
+		case "target", "dst", "destination":
+			mount.Target = fieldValue
+		}
+	}
+	if mount.Target == "" {
+		return Mount{}, fmt.Errorf("invalid mount string %q: missing target", value)
+	}
+	return mount, nil
 }
 
 type DevContainer struct {

--- a/pkg/devcontainer/devcontainer_test.go
+++ b/pkg/devcontainer/devcontainer_test.go
@@ -1783,3 +1783,102 @@ func TestHasFeatures(t *testing.T) {
 		})
 	}
 }
+
+func writeTempDevcontainer(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "devcontainer.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write devcontainer.json: %v", err)
+	}
+	return path
+}
+
+func TestParse_MountsObjectFormat(t *testing.T) {
+	path := writeTempDevcontainer(t, `{
+		"image": "node:22",
+		"mounts": [
+			{"type": "bind", "source": "/host/dir", "target": "/container/dir"}
+		]
+	}`)
+
+	dc, err := Parse(path)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(dc.Mounts) != 1 {
+		t.Fatalf("len(Mounts) = %d, want 1", len(dc.Mounts))
+	}
+	expected := Mount{Type: "bind", Source: "/host/dir", Target: "/container/dir"}
+	if dc.Mounts[0] != expected {
+		t.Errorf("Mounts[0] = %+v, want %+v", dc.Mounts[0], expected)
+	}
+}
+
+func TestParse_MountsStringFormat(t *testing.T) {
+	path := writeTempDevcontainer(t, `{
+		"image": "node:22",
+		"mounts": [
+			"source=/host/dir,target=/container/dir,type=bind"
+		]
+	}`)
+
+	dc, err := Parse(path)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(dc.Mounts) != 1 {
+		t.Fatalf("len(Mounts) = %d, want 1", len(dc.Mounts))
+	}
+	expected := Mount{Type: "bind", Source: "/host/dir", Target: "/container/dir"}
+	if dc.Mounts[0] != expected {
+		t.Errorf("Mounts[0] = %+v, want %+v", dc.Mounts[0], expected)
+	}
+}
+
+func TestParse_MountsStringFormatAliases(t *testing.T) {
+	path := writeTempDevcontainer(t, `{
+		"image": "node:22",
+		"mounts": [
+			"src=myvolume,dst=/data,type=volume"
+		]
+	}`)
+
+	dc, err := Parse(path)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(dc.Mounts) != 1 {
+		t.Fatalf("len(Mounts) = %d, want 1", len(dc.Mounts))
+	}
+	expected := Mount{Type: "volume", Source: "myvolume", Target: "/data"}
+	if dc.Mounts[0] != expected {
+		t.Errorf("Mounts[0] = %+v, want %+v", dc.Mounts[0], expected)
+	}
+}
+
+func TestParse_MountsMixedFormats(t *testing.T) {
+	path := writeTempDevcontainer(t, `{
+		"image": "node:22",
+		"mounts": [
+			"source=/host/a,target=/a,type=bind",
+			{"type": "volume", "source": "vol", "target": "/b"}
+		]
+	}`)
+
+	dc, err := Parse(path)
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if len(dc.Mounts) != 2 {
+		t.Fatalf("len(Mounts) = %d, want 2", len(dc.Mounts))
+	}
+	expectedFirst := Mount{Type: "bind", Source: "/host/a", Target: "/a"}
+	if dc.Mounts[0] != expectedFirst {
+		t.Errorf("Mounts[0] = %+v, want %+v", dc.Mounts[0], expectedFirst)
+	}
+	expectedSecond := Mount{Type: "volume", Source: "vol", Target: "/b"}
+	if dc.Mounts[1] != expectedSecond {
+		t.Errorf("Mounts[1] = %+v, want %+v", dc.Mounts[1], expectedSecond)
+	}
+}


### PR DESCRIPTION
## Summary

The devcontainer spec allows entries of `mounts` to be written either as objects (`{"type": ..., "source": ..., "target": ...}`) or as Docker CLI style strings (`"source=/host,target=/container,type=bind"`). devgo only accepted the object form; the string form failed with:

```
failed to parse devcontainer.json: json: cannot unmarshal string into Go value of type devcontainer.Mount
```

## Changes

- Implement `Mount.UnmarshalJSON` that accepts both forms.
- Accept `src`, `dst`, and `destination` key aliases following Docker's `--mount` syntax.
- Ignore unknown keys (e.g. `consistency`, `readonly`) instead of failing the parse.
- Reject mount strings without a `target`.

## Test plan

- New parse tests cover the object form, the string form, key aliases, and mixed arrays. The string form tests fail without the fix.
- `make test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyCNS4VUn2VfGwvYyhpzfc