### PR TITLE
Apply devcontainer.json mounts on container creation

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/garaemon/devgo/pkg/config"
@@ -31,6 +32,7 @@ type DockerRunArgs struct {
 	WorkspaceDir    string
 	WorkspaceFolder string
 	Env             map[string]string
+	Mounts          []devcontainer.Mount
 }
 
 // DockerClient interface for Docker operations
@@ -184,7 +186,7 @@ func startContainerWithDocker(ctx context.Context, devContainer *devcontainer.De
 			return fmt.Errorf("container '%s' is already running", containerName)
 		}
 		debugf("Container '%s' exists but is stopped, removing and recreating it to apply configuration changes\n", containerName)
-		
+
 		// Use raw docker client to remove the container
 		cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 		if err == nil {
@@ -210,6 +212,7 @@ func startContainerWithDocker(ctx context.Context, devContainer *devcontainer.De
 		WorkspaceDir:    workspaceDir,
 		WorkspaceFolder: devContainer.GetWorkspaceFolder(),
 		Env:             expandedEnv,
+		Mounts:          devContainer.Mounts,
 	}
 
 	if err := dockerClient.CreateAndStartContainer(ctx, dockerArgs); err != nil {
@@ -478,7 +481,12 @@ func (r *realDockerClient) CreateAndStartContainer(ctx context.Context, args Doc
 	}
 
 	hostConfig := &container.HostConfig{
-		Binds: binds,
+		Binds:  binds,
+		Mounts: buildMounts(args.Mounts),
+	}
+
+	if len(args.Mounts) > 0 {
+		debugf("Applying %d mounts from devcontainer.json\n", len(args.Mounts))
 	}
 
 	// Create the container
@@ -495,6 +503,25 @@ func (r *realDockerClient) CreateAndStartContainer(ctx context.Context, args Doc
 
 	debugf("Container '%s' started successfully\n", args.Name)
 	return nil
+}
+
+// buildMounts converts devcontainer.json mounts into Docker API mounts.
+// The mount type defaults to "bind" when omitted, matching the behavior
+// of the official devcontainer-cli.
+func buildMounts(mounts []devcontainer.Mount) []mount.Mount {
+	var dockerMounts []mount.Mount
+	for _, m := range mounts {
+		mountType := m.Type
+		if mountType == "" {
+			mountType = "bind"
+		}
+		dockerMounts = append(dockerMounts, mount.Mount{
+			Type:   mount.Type(mountType),
+			Source: m.Source,
+			Target: m.Target,
+		})
+	}
+	return dockerMounts
 }
 
 func (r *realDockerClient) ImageExists(ctx context.Context, imageName string) (bool, error) {

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -311,11 +311,12 @@ func TestDetermineContainerName(t *testing.T) {
 
 // mockDockerAPIClient implements the dockerAPIClient interface for testing
 type mockDockerAPIClient struct {
-	containers     []container.Summary
-	images         []image.Summary
-	listError      error
-	imageListError error
-	pullError      error
+	containers         []container.Summary
+	images             []image.Summary
+	listError          error
+	imageListError     error
+	pullError          error
+	createdHostConfigs []*container.HostConfig
 }
 
 func (m *mockDockerAPIClient) ContainerList(ctx context.Context, options container.ListOptions) ([]container.Summary, error) {
@@ -330,6 +331,7 @@ func (m *mockDockerAPIClient) ContainerStart(ctx context.Context, containerID st
 }
 
 func (m *mockDockerAPIClient) ContainerCreate(ctx context.Context, config *container.Config, hostConfig *container.HostConfig, networkingConfig *network.NetworkingConfig, platform *v1.Platform, containerName string) (container.CreateResponse, error) {
+	m.createdHostConfigs = append(m.createdHostConfigs, hostConfig)
 	return container.CreateResponse{}, nil
 }
 
@@ -1609,5 +1611,98 @@ func TestUpdateRemoteUserUID(t *testing.T) {
 					tt.description, tt.shouldUpdate, willExecute, shouldUpdate, hasCompose, targetUser)
 			}
 		})
+	}
+}
+
+func TestCreateAndStartContainerAppliesMounts(t *testing.T) {
+	mockAPI := &mockDockerAPIClient{}
+	dockerClient := &realDockerClient{client: mockAPI}
+
+	args := DockerRunArgs{
+		Name:            "test-container",
+		Image:           "node:22",
+		WorkspaceDir:    "/host/project",
+		WorkspaceFolder: "/workspace",
+		Mounts: []devcontainer.Mount{
+			{Type: "bind", Source: "/host/dir", Target: "/container/dir"},
+			{Type: "volume", Source: "myvolume", Target: "/data"},
+		},
+	}
+
+	if err := dockerClient.CreateAndStartContainer(context.Background(), args); err != nil {
+		t.Fatalf("CreateAndStartContainer() error = %v", err)
+	}
+
+	if len(mockAPI.createdHostConfigs) != 1 {
+		t.Fatalf("len(createdHostConfigs) = %d, want 1", len(mockAPI.createdHostConfigs))
+	}
+	hostConfig := mockAPI.createdHostConfigs[0]
+	if len(hostConfig.Mounts) != 2 {
+		t.Fatalf("len(hostConfig.Mounts) = %d, want 2", len(hostConfig.Mounts))
+	}
+	first := hostConfig.Mounts[0]
+	if string(first.Type) != "bind" || first.Source != "/host/dir" || first.Target != "/container/dir" {
+		t.Errorf("Mounts[0] = %+v, want bind /host/dir -> /container/dir", first)
+	}
+	second := hostConfig.Mounts[1]
+	if string(second.Type) != "volume" || second.Source != "myvolume" || second.Target != "/data" {
+		t.Errorf("Mounts[1] = %+v, want volume myvolume -> /data", second)
+	}
+}
+
+func TestCreateAndStartContainerDefaultsMountTypeToBind(t *testing.T) {
+	mockAPI := &mockDockerAPIClient{}
+	dockerClient := &realDockerClient{client: mockAPI}
+
+	args := DockerRunArgs{
+		Name:            "test-container",
+		Image:           "node:22",
+		WorkspaceDir:    "/host/project",
+		WorkspaceFolder: "/workspace",
+		Mounts: []devcontainer.Mount{
+			{Source: "/host/dir", Target: "/container/dir"},
+		},
+	}
+
+	if err := dockerClient.CreateAndStartContainer(context.Background(), args); err != nil {
+		t.Fatalf("CreateAndStartContainer() error = %v", err)
+	}
+
+	hostConfig := mockAPI.createdHostConfigs[0]
+	if len(hostConfig.Mounts) != 1 {
+		t.Fatalf("len(hostConfig.Mounts) = %d, want 1", len(hostConfig.Mounts))
+	}
+	if string(hostConfig.Mounts[0].Type) != "bind" {
+		t.Errorf("Mounts[0].Type = %q, want \"bind\"", hostConfig.Mounts[0].Type)
+	}
+}
+
+func TestStartContainerWithDockerPassesMounts(t *testing.T) {
+	mockClient := newMockDockerClient()
+	mockClient.addImage("node:22")
+
+	devContainer := &devcontainer.DevContainer{
+		Image: "node:22",
+		Mounts: []devcontainer.Mount{
+			{Type: "bind", Source: "/host/dir", Target: "/container/dir"},
+		},
+	}
+
+	err := startContainerWithDocker(context.Background(), devContainer,
+		"test-mounts-container", "/host/project", mockClient)
+	if err != nil {
+		t.Fatalf("startContainerWithDocker() error = %v", err)
+	}
+
+	if len(mockClient.createdContainers) != 1 {
+		t.Fatalf("len(createdContainers) = %d, want 1", len(mockClient.createdContainers))
+	}
+	created := mockClient.createdContainers[0]
+	if len(created.Mounts) != 1 {
+		t.Fatalf("len(created.Mounts) = %d, want 1", len(created.Mounts))
+	}
+	expected := devcontainer.Mount{Type: "bind", Source: "/host/dir", Target: "/container/dir"}
+	if created.Mounts[0] != expected {
+		t.Errorf("created.Mounts[0] = %+v, want %+v", created.Mounts[0], expected)
 	}
 }


### PR DESCRIPTION
## Summary

The `mounts` field of `devcontainer.json` was parsed into the `DevContainer` struct but never used when creating a container. Custom bind mounts and volumes were silently ignored; only the workspace bind and the SSH agent socket were mounted.

## Changes

- Add `Mounts` to `DockerRunArgs` and pass the parsed mounts from `startContainerWithDocker`.
- Add `buildMounts` that translates devcontainer mounts into Docker API mounts (`HostConfig.Mounts`).
- Default the mount type to `bind` when omitted, matching the official devcontainer-cli.

## Test plan

- `TestCreateAndStartContainerAppliesMounts` verifies mounts reach `HostConfig.Mounts` (fails without the fix).
- `TestCreateAndStartContainerDefaultsMountTypeToBind` covers the default type.
- `TestStartContainerWithDockerPassesMounts` covers the plumbing from the parsed config.
- `make test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyCNS4VUn2VfGwvYyhpzfc