### PR TITLE
Pass flags after the exec command through to the container

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,6 +41,13 @@ func parseAllFlags(args []string) ([]string, error) {
 
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
+		// For "exec", everything after the command to run belongs to that
+		// command, so stop interpreting flags once it appears. Without this,
+		// "devgo exec claude --version" would print devgo's own version.
+		if isExecPassthroughStarted(nonFlagArgs) {
+			nonFlagArgs = append(nonFlagArgs, arg)
+			continue
+		}
 		if arg == "--help" || arg == "-h" {
 			showHelp = true
 		} else if arg == "--version" {
@@ -99,6 +106,13 @@ func parseAllFlags(args []string) ([]string, error) {
 	}
 
 	return nonFlagArgs, nil
+}
+
+// isExecPassthroughStarted reports whether flag parsing reached the command
+// that "devgo exec" runs inside the container. From that point on, remaining
+// arguments are passed to the container command verbatim.
+func isExecPassthroughStarted(nonFlagArgs []string) bool {
+	return len(nonFlagArgs) >= 2 && nonFlagArgs[0] == "exec"
 }
 
 func Execute() error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -567,3 +567,74 @@ func TestExecute_Help(t *testing.T) {
 		t.Errorf("stderr should contain usage help, got: %s", stderrOutput)
 	}
 }
+
+func TestParseAllFlagsExecPassthrough(t *testing.T) {
+	tests := []struct {
+		name            string
+		args            []string
+		expectedArgs    []string
+		expectedVersion bool
+		expectedHelp    bool
+	}{
+		{
+			name:            "version flag after exec command passes through",
+			args:            []string{"exec", "claude", "--version"},
+			expectedArgs:    []string{"exec", "claude", "--version"},
+			expectedVersion: false,
+		},
+		{
+			name:         "help flag after exec command passes through",
+			args:         []string{"exec", "ls", "--help"},
+			expectedArgs: []string{"exec", "ls", "--help"},
+			expectedHelp: false,
+		},
+		{
+			name:         "unknown flag after exec command passes through",
+			args:         []string{"exec", "npm", "install", "--save-dev", "typescript"},
+			expectedArgs: []string{"exec", "npm", "install", "--save-dev", "typescript"},
+		},
+		{
+			name:         "devgo flags between exec and command are still parsed",
+			args:         []string{"exec", "--workspace-folder", "/path", "claude", "--version"},
+			expectedArgs: []string{"exec", "claude", "--version"},
+		},
+		{
+			name:            "version flag before exec is parsed by devgo",
+			args:            []string{"--version", "exec", "claude"},
+			expectedArgs:    []string{"exec", "claude"},
+			expectedVersion: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			showHelp = false
+			showVersion = false
+			workspaceFolder = ""
+			defer func() {
+				showHelp = false
+				showVersion = false
+				workspaceFolder = ""
+			}()
+
+			result, err := parseAllFlags(tt.args)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(result) != len(tt.expectedArgs) {
+				t.Fatalf("parseAllFlags() = %v, want %v", result, tt.expectedArgs)
+			}
+			for i, arg := range tt.expectedArgs {
+				if result[i] != arg {
+					t.Errorf("parseAllFlags()[%d] = %q, want %q", i, result[i], arg)
+				}
+			}
+			if showVersion != tt.expectedVersion {
+				t.Errorf("showVersion = %v, want %v", showVersion, tt.expectedVersion)
+			}
+			if showHelp != tt.expectedHelp {
+				t.Errorf("showHelp = %v, want %v", showHelp, tt.expectedHelp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`parseAllFlags` interpreted every flag anywhere on the command line. As a result:

- `devgo exec claude --version` printed devgo's own version instead of running `claude --version` inside the container.
- `devgo exec npm install --save-dev typescript` failed with `unknown option: --save-dev`.

## Changes

- Stop interpreting flags once the command that `exec` runs appears; everything after it is passed to the container command verbatim.
- Flags placed before the command (e.g. `devgo exec --workspace-folder <path> <cmd>`) are still parsed by devgo.

## Test plan

- New table-driven test `TestParseAllFlagsExecPassthrough` covers passthrough of `--version`, `--help`, and unknown flags, plus devgo flags before the command (fails without the fix).
- Manually confirmed `devgo exec claude --version` now reaches the container exec path.
- `make test` and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyCNS4VUn2VfGwvYyhpzfc