### PR TITLE
Add Claude Code sample devcontainer configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ devgo --help
    devgo down
    ```
 
+## Samples
+
+The [samples](samples/) directory contains ready-to-use devcontainer
+configurations:
+
+- [claude-code](samples/claude-code/): Run Claude Code inside a devgo
+  container, reusing the Claude Code credentials from your host.
+
 ## Command Reference
 
 ### `devgo init`

--- a/samples/claude-code/.devcontainer/devcontainer.json
+++ b/samples/claude-code/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  // Sample devcontainer for running Claude Code inside a devgo container.
+  // See samples/claude-code/README.md for setup instructions.
+  "name": "claude-code-sample",
+  "image": "node:22",
+  // Share the host Claude Code configuration (including credentials)
+  // with the container. Replace /home/YOUR_USER with your host home
+  // directory; devgo does not expand ${localEnv:HOME} in mounts yet.
+  "mounts": [
+    {
+      "type": "bind",
+      "source": "/home/YOUR_USER/.claude",
+      "target": "/root/.claude"
+    }
+  ],
+  // Install Claude Code and mark onboarding as done so that headless
+  // (claude -p) invocations work without an interactive first run.
+  "postCreateCommand": "npm install -g @anthropic-ai/claude-code && { [ -f /root/.claude.json ] || echo '{\"hasCompletedOnboarding\": true}' > /root/.claude.json; }"
+}

--- a/samples/claude-code/README.md
+++ b/samples/claude-code/README.md
@@ -1,0 +1,84 @@
+# Running Claude Code in a devgo container
+
+This sample shows how to run [Claude Code](https://claude.com/claude-code)
+inside a container managed by devgo. The container reuses the Claude Code
+credentials from your host, so you do not need to log in again inside the
+container.
+
+## Prerequisites
+
+- devgo and Docker (or Podman) installed on the host.
+- Claude Code installed and logged in on the host. The login stores an
+  OAuth credential in `~/.claude/.credentials.json`.
+
+## Setup
+
+1. Copy this directory to your project, or use it as-is for a quick trial.
+
+2. Edit `.devcontainer/devcontainer.json` and replace `/home/YOUR_USER`
+   in the mount source with your host home directory. devgo does not
+   expand `${localEnv:HOME}` in mounts yet.
+
+3. Start the container from this directory:
+
+   ```bash
+   devgo up
+   ```
+
+   The `postCreateCommand` installs Claude Code with npm and prepares the
+   configuration for headless use.
+
+## Usage
+
+Run a one-shot prompt:
+
+```bash
+devgo exec claude -p "Explain this project"
+```
+
+Or work interactively:
+
+```bash
+devgo shell
+# inside the container
+claude
+```
+
+Stop and remove the container when done:
+
+```bash
+devgo down
+```
+
+## How credential sharing works
+
+The sample bind-mounts the host `~/.claude` directory to `/root/.claude`
+in the container. Claude Code reads `.credentials.json` from that
+directory, so the container reuses the host login session.
+
+Two caveats to keep in mind:
+
+- The mount is read-write. Claude Code running in the container can
+  update files under your host `~/.claude` (history, settings, and
+  refreshed credentials).
+- The credential file grants access to your Claude account. Only use
+  this setup with containers and images you trust.
+
+If you prefer to keep the host directory untouched, copy only the
+credential file into a separate directory and mount that instead:
+
+```bash
+mkdir -p ~/claude-container-home
+cp ~/.claude/.credentials.json ~/claude-container-home/
+```
+
+Then point the mount source at `~/claude-container-home` (as an absolute
+path) instead of `~/.claude`.
+
+## Notes
+
+- The `node:22` image runs as root, so the mount target is
+  `/root/.claude`. If your image uses a non-root user, change the target
+  to that user's home directory (e.g. `/home/node/.claude`).
+- Requires devgo with support for applying `mounts` from
+  devcontainer.json.


### PR DESCRIPTION
## Summary

Add a `samples/` directory with a ready-to-use configuration for running Claude Code inside a devgo container. Verified end-to-end on a real container: installing Claude Code in `node:22`, reusing host credentials, and running both headless (`claude -p`) and interactive sessions.

## Changes

- `samples/claude-code/.devcontainer/devcontainer.json`: `node:22` image, bind mount of the host `~/.claude` directory, and a `postCreateCommand` that installs Claude Code.
- `samples/claude-code/README.md`: setup steps, usage, and a section on how credential sharing works, including a safer copy-only alternative and security caveats.
- `README.md`: new "Samples" section linking to the directory.

## Notes

- The sample relies on `mounts` support from #79 and #80.
- Flag passthrough for `devgo exec claude --version` style commands is fixed in #81.

## Test plan

- Docs and sample config only; `make test` and `make lint` still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyCNS4VUn2VfGwvYyhpzfc