### PR TITLE
Syntax-highlight Go sources in the HTML coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,9 +564,9 @@ make coverage-report
 make coverage-diff BASE=origin/main
 ```
 
-The HTML report has a per-file sidebar and marks covered and uncovered lines
-with tinted backgrounds, replacing the hard-to-read default theme of
-`go tool cover -html`.
+The HTML report has a per-file sidebar, syntax-highlighted Go sources, and
+marks covered and uncovered lines with tinted backgrounds, replacing the
+hard-to-read default theme of `go tool cover -html`.
 
 `make coverage-diff` renders only the changed hunks plus three lines of
 context; the page holds both views, so the header toggle switches between

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -245,6 +245,147 @@ func TestAnnotateFileUncoveredWins(t *testing.T) {
 	}
 }
 
+func TestHighlightLines(t *testing.T) {
+	src := "package p\n" +
+		"\n" +
+		"// count returns 2 < 3 & more.\n" +
+		"func count(s string) int {\n" +
+		"\treturn len(s) + 42\n" +
+		"}\n"
+
+	got := highlightLines("p.go", src)
+	if want := strings.Split(src, "\n"); len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d", len(got), len(want))
+	}
+	checks := []struct {
+		line int
+		want string
+	}{
+		{1, `<span class="k">package</span> p`},
+		{3, `<span class="c">// count returns 2 &lt; 3 &amp; more.</span>`},
+		{4, `<span class="k">func</span> <span class="f">count</span>(s ` +
+			`<span class="b">string</span>) <span class="b">int</span> {`},
+		{5, "\t<span class=\"k\">return</span> <span class=\"b\">len</span>(s) + " +
+			`<span class="m">42</span>`},
+	}
+	for _, c := range checks {
+		if string(got[c.line-1]) != c.want {
+			t.Errorf("line %d =\n  %s\nwant\n  %s", c.line, got[c.line-1], c.want)
+		}
+	}
+}
+
+// Only declared functions and methods get the name colour. A func *type*
+// looks the same lexically up to its closing paren, so the distinguishing
+// signal is what follows the identifier.
+func TestHighlightLinesFuncNames(t *testing.T) {
+	tests := []struct {
+		name, src, want string
+	}{
+		{
+			name: "method",
+			src:  "func (r *T) Do(a int) {}",
+			want: `<span class="k">func</span> (r *T) <span class="f">Do</span>` +
+				`(a <span class="b">int</span>) {}`,
+		},
+		{
+			name: "generic function",
+			src:  "func Map[K any](m K) {}",
+			want: `<span class="k">func</span> <span class="f">Map</span>` +
+				`[K <span class="b">any</span>](m K) {}`,
+		},
+		{
+			name: "func type keeps its return type",
+			src:  "var f func(int) int",
+			want: `<span class="k">var</span> f <span class="k">func</span>` +
+				`(<span class="b">int</span>) <span class="b">int</span>`,
+		},
+		{
+			name: "func literal has no name",
+			src:  "var g = func(x int) int { return x }",
+			want: `<span class="k">var</span> g = <span class="k">func</span>` +
+				`(x <span class="b">int</span>) <span class="b">int</span> { ` +
+				`<span class="k">return</span> x }`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := highlightLines("p.go", "package p\n"+tt.src+"\n")
+			if len(got) != 3 {
+				t.Fatalf("got %d lines, want 3", len(got))
+			}
+			if string(got[1]) != tt.want {
+				t.Errorf("got\n  %s\nwant\n  %s", got[1], tt.want)
+			}
+		})
+	}
+}
+
+// Raw strings and block comments cover several rows, and each row is wrapped
+// on its own so the coverage tint of the rows around them stays intact.
+func TestHighlightLinesMultiLineTokens(t *testing.T) {
+	src := "package p\n" +
+		"\n" +
+		"/* one\n" +
+		"   two */\n" +
+		"var s = `raw <\n" +
+		"line`\n"
+
+	got := highlightLines("p.go", src)
+	want := []string{
+		`<span class="k">package</span> p`,
+		``,
+		`<span class="c">/* one</span>`,
+		`<span class="c">   two */</span>`,
+		`<span class="k">var</span> s = <span class="s">` + "`raw &lt;" + `</span>`,
+		`<span class="s">line` + "`" + `</span>`,
+		``,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d lines, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if string(got[i]) != want[i] {
+			t.Errorf("line %d =\n  %s\nwant\n  %s", i+1, got[i], want[i])
+		}
+	}
+}
+
+// Anything that is not tokenizable Go still has to render, escaped and with
+// its line count intact, since the rows carry the line numbers.
+func TestHighlightLinesFallback(t *testing.T) {
+	tests := []struct {
+		name, rel, src string
+		want           []string
+	}{
+		{
+			name: "not a go file",
+			rel:  "notes.txt",
+			src:  "func x() <b>\nplain\n",
+			want: []string{"func x() &lt;b&gt;", "plain", ""},
+		},
+		{
+			name: "unscannable go source",
+			rel:  "broken.go",
+			src:  "package p\nvar s = \"unterminated & <\n",
+			want: []string{"package p", `var s = &#34;unterminated &amp; &lt;`, ""},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := highlightLines(tt.rel, tt.src)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d lines, want %d", len(got), len(tt.want))
+			}
+			for i := range tt.want {
+				if string(got[i]) != tt.want[i] {
+					t.Errorf("line %d = %q, want %q", i+1, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestPatchTallies(t *testing.T) {
 	const module = "example.com/m"
 	head := profile{

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -248,15 +248,15 @@ func TestAnnotateFileUncoveredWins(t *testing.T) {
 }
 
 func TestHighlightLines(t *testing.T) {
-	src := "package p\n" +
+	sourceText := "package p\n" +
 		"\n" +
 		"// count returns 2 < 3 & more.\n" +
 		"func count(s string) int {\n" +
 		"\treturn len(s) + 42\n" +
 		"}\n"
 
-	got := highlightLines("p.go", src)
-	if want := strings.Split(src, "\n"); len(got) != len(want) {
+	got := highlightLines("p.go", sourceText)
+	if want := strings.Split(sourceText, "\n"); len(got) != len(want) {
 		t.Fatalf("got %d lines, want %d", len(got), len(want))
 	}
 	checks := []struct {
@@ -282,42 +282,42 @@ func TestHighlightLines(t *testing.T) {
 // signal is what follows the identifier.
 func TestHighlightLinesFuncNames(t *testing.T) {
 	tests := []struct {
-		name, src, want string
+		name, sourceText, want string
 	}{
 		{
-			name: "method",
-			src:  "func (r *T) Do(a int) {}",
+			name:       "method",
+			sourceText: "func (r *T) Do(a int) {}",
 			want: `<span class="k">func</span> (r *T) <span class="f">Do</span>` +
 				`(a <span class="b">int</span>) {}`,
 		},
 		{
-			name: "generic function",
-			src:  "func Map[K any](m K) {}",
+			name:       "generic function",
+			sourceText: "func Map[K any](m K) {}",
 			want: `<span class="k">func</span> <span class="f">Map</span>` +
 				`[K <span class="b">any</span>](m K) {}`,
 		},
 		{
-			name: "func type keeps its return type",
-			src:  "var f func(int) int",
+			name:       "func type keeps its return type",
+			sourceText: "var f func(int) int",
 			want: `<span class="k">var</span> f <span class="k">func</span>` +
 				`(<span class="b">int</span>) <span class="b">int</span>`,
 		},
 		{
-			name: "func literal has no name",
-			src:  "var g = func(x int) int { return x }",
+			name:       "func literal has no name",
+			sourceText: "var g = func(x int) int { return x }",
 			want: `<span class="k">var</span> g = <span class="k">func</span>` +
 				`(x <span class="b">int</span>) <span class="b">int</span> { ` +
 				`<span class="k">return</span> x }`,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := highlightLines("p.go", "package p\n"+tt.src+"\n")
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := highlightLines("p.go", "package p\n"+testCase.sourceText+"\n")
 			if len(got) != 3 {
 				t.Fatalf("got %d lines, want 3", len(got))
 			}
-			if string(got[1]) != tt.want {
-				t.Errorf("got\n  %s\nwant\n  %s", got[1], tt.want)
+			if string(got[1]) != testCase.want {
+				t.Errorf("got\n  %s\nwant\n  %s", got[1], testCase.want)
 			}
 		})
 	}
@@ -326,14 +326,14 @@ func TestHighlightLinesFuncNames(t *testing.T) {
 // Raw strings and block comments cover several rows, and each row is wrapped
 // on its own so the coverage tint of the rows around them stays intact.
 func TestHighlightLinesMultiLineTokens(t *testing.T) {
-	src := "package p\n" +
+	sourceText := "package p\n" +
 		"\n" +
 		"/* one\n" +
 		"   two */\n" +
 		"var s = `raw <\n" +
 		"line`\n"
 
-	got := highlightLines("p.go", src)
+	got := highlightLines("p.go", sourceText)
 	want := []string{
 		`<span class="k">package</span> p`,
 		``,
@@ -357,31 +357,31 @@ func TestHighlightLinesMultiLineTokens(t *testing.T) {
 // its line count intact, since the rows carry the line numbers.
 func TestHighlightLinesFallback(t *testing.T) {
 	tests := []struct {
-		name, rel, src string
-		want           []string
+		name, relPath, sourceText string
+		want                      []string
 	}{
 		{
-			name: "not a go file",
-			rel:  "notes.txt",
-			src:  "func x() <b>\nplain\n",
-			want: []string{"func x() &lt;b&gt;", "plain", ""},
+			name:       "not a go file",
+			relPath:    "notes.txt",
+			sourceText: "func x() <b>\nplain\n",
+			want:       []string{"func x() &lt;b&gt;", "plain", ""},
 		},
 		{
-			name: "unscannable go source",
-			rel:  "broken.go",
-			src:  "package p\nvar s = \"unterminated & <\n",
-			want: []string{"package p", `var s = &#34;unterminated &amp; &lt;`, ""},
+			name:       "unscannable go source",
+			relPath:    "broken.go",
+			sourceText: "package p\nvar s = \"unterminated & <\n",
+			want:       []string{"package p", `var s = &#34;unterminated &amp; &lt;`, ""},
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := highlightLines(tt.rel, tt.src)
-			if len(got) != len(tt.want) {
-				t.Fatalf("got %d lines, want %d", len(got), len(tt.want))
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := highlightLines(testCase.relPath, testCase.sourceText)
+			if len(got) != len(testCase.want) {
+				t.Fatalf("got %d lines, want %d", len(got), len(testCase.want))
 			}
-			for i := range tt.want {
-				if string(got[i]) != tt.want[i] {
-					t.Errorf("line %d = %q, want %q", i+1, got[i], tt.want[i])
+			for i := range testCase.want {
+				if string(got[i]) != testCase.want[i] {
+					t.Errorf("line %d = %q, want %q", i+1, got[i], testCase.want[i])
 				}
 			}
 		})

--- a/tools/covreport/html.go
+++ b/tools/covreport/html.go
@@ -161,7 +161,7 @@ type htmlFile struct {
 type htmlLine struct {
 	Num     int
 	Class   string // "", "cov", or "uncov"
-	Text    string
+	Text    template.HTML
 	Added   bool
 	Visible bool
 	Gap     int
@@ -210,7 +210,7 @@ func diffRegions(added []int, totalLines, context int) []region {
 // Uncovered wins over covered when a line spans blocks of both kinds, so red
 // always flags lines that still need a test.
 func annotateFile(rel, src string, blocks []block, added []int, context int) htmlFile {
-	srcLines := strings.Split(src, "\n")
+	srcLines := highlightLines(rel, src)
 	total := len(srcLines)
 
 	classes := make([]string, total+1)
@@ -289,6 +289,8 @@ var htmlTemplate = template.Must(template.New("report").Parse(`<!DOCTYPE html>
   --cov-bg: #e6f4ea; --cov-edge: #1a7f37;
   --uncov-bg: #ffebe9; --uncov-edge: #cf222e;
   --add-bg: #eef4ff; --add-edge: #0969da; --gap-fg: #656d76;
+  --tk-key: #cf222e; --tk-str: #0a3069; --tk-num: #0550ae;
+  --tk-com: #57606a; --tk-bui: #0550ae; --tk-fun: #6639ba;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -297,6 +299,8 @@ var htmlTemplate = template.Must(template.New("report").Parse(`<!DOCTYPE html>
     --cov-bg: #12261e; --cov-edge: #2ea043;
     --uncov-bg: #2d1517; --uncov-edge: #f85149;
     --add-bg: #10203a; --add-edge: #4493f8; --gap-fg: #8d96a0;
+    --tk-key: #ff7b72; --tk-str: #a5d6ff; --tk-num: #79c0ff;
+    --tk-com: #9198a1; --tk-bui: #79c0ff; --tk-fun: #d2a8ff;
   }
 }
 * { box-sizing: border-box; }
@@ -352,7 +356,8 @@ pre {
   margin: 0; font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo,
   Consolas, monospace; min-width: max-content; tab-size: 4;
 }
-pre span { display: block; padding: 0 16px 0 0; }
+/* Direct children only: the rows. Token spans nested inside must stay inline. */
+pre > span { display: block; padding: 0 16px 0 0; }
 pre .n {
   display: inline-block; width: 4.5em; text-align: right;
   padding-right: 12px; color: var(--muted); user-select: none;
@@ -364,6 +369,13 @@ pre .g {
 /* Tabs are measured from the start of the line box, so the code must live
    in its own inline-block for indentation to survive the number prefix. */
 pre .t { display: inline-block; white-space: pre; vertical-align: top; }
+/* Syntax colours, chosen to stay legible on the coverage tints. */
+pre .t .k { color: var(--tk-key); }
+pre .t .s { color: var(--tk-str); }
+pre .t .m { color: var(--tk-num); }
+pre .t .b { color: var(--tk-bui); }
+pre .t .f { color: var(--tk-fun); }
+pre .t .c { color: var(--tk-com); font-style: italic; }
 pre .cov { background: var(--cov-bg); box-shadow: inset 3px 0 var(--cov-edge); }
 pre .uncov { background: var(--uncov-bg); box-shadow: inset 3px 0 var(--uncov-edge); }
 pre .gap {

--- a/tools/covreport/syntax.go
+++ b/tools/covreport/syntax.go
@@ -1,0 +1,260 @@
+package main
+
+import (
+	"go/scanner"
+	"go/token"
+	"html/template"
+	"strings"
+)
+
+// Token classes used in the rendered HTML. Kept to one letter because every
+// token in the report carries one, and none of them collide with the row
+// classes (n, g, t, cov, uncov, add, off, gap).
+const (
+	classKeyword    = "k"
+	classString     = "s"
+	classNumber     = "m"
+	classComment    = "c"
+	classPredeclare = "b"
+	classFuncName   = "f"
+)
+
+// predeclared are the identifiers in Go's universe block. They are not
+// keywords, so the scanner reports them as plain identifiers.
+var predeclared = map[string]bool{
+	"any": true, "bool": true, "byte": true, "comparable": true,
+	"complex64": true, "complex128": true, "error": true, "float32": true,
+	"float64": true, "int": true, "int8": true, "int16": true, "int32": true,
+	"int64": true, "rune": true, "string": true, "uint": true, "uint8": true,
+	"uint16": true, "uint32": true, "uint64": true, "uintptr": true,
+
+	"false": true, "iota": true, "nil": true, "true": true,
+
+	"append": true, "cap": true, "clear": true, "close": true,
+	"complex": true, "copy": true, "delete": true, "imag": true, "len": true,
+	"make": true, "max": true, "min": true, "new": true, "panic": true,
+	"print": true, "println": true, "real": true, "recover": true,
+}
+
+// tokenSpan is a half-open byte range of src that should be wrapped in class.
+type tokenSpan struct {
+	start, end int
+	class      string
+}
+
+// highlightLines splits src into one HTML fragment per line, matching
+// strings.Split(src, "\n") element for element. Go sources get their tokens
+// wrapped in class spans; anything else — and any source the scanner chokes
+// on — falls back to plain escaped text.
+func highlightLines(rel, src string) []template.HTML {
+	if !strings.HasSuffix(rel, ".go") {
+		return plainLines(src)
+	}
+	spans, ok := goTokenSpans(src)
+	if !ok {
+		return plainLines(src)
+	}
+	return assembleLines(src, spans)
+}
+
+func plainLines(src string) []template.HTML {
+	raw := strings.Split(src, "\n")
+	out := make([]template.HTML, len(raw))
+	for i, l := range raw {
+		out[i] = template.HTML(template.HTMLEscapeString(l))
+	}
+	return out
+}
+
+// scanned is one token, with the source range it actually occupies.
+type scanned struct {
+	tok        token.Token
+	lit        string
+	start, end int
+}
+
+// goTokenSpans tokenizes src and returns the ranges worth colouring, in
+// source order and never overlapping. It reports false when the scanner
+// finds a syntax error, so a source that cannot be tokenized cleanly renders
+// as plain text instead of being mis-coloured.
+func goTokenSpans(src string) ([]tokenSpan, bool) {
+	toks, ok := scanTokens(src)
+	if !ok {
+		return nil, false
+	}
+	names := funcNameIndexes(toks)
+
+	spans := make([]tokenSpan, 0, len(toks))
+	for i, t := range toks {
+		class := ""
+		switch {
+		case t.tok == token.COMMENT:
+			class = classComment
+		case t.tok == token.STRING, t.tok == token.CHAR:
+			class = classString
+		case t.tok == token.INT, t.tok == token.FLOAT, t.tok == token.IMAG:
+			class = classNumber
+		case t.tok.IsKeyword():
+			class = classKeyword
+		case names[i]:
+			class = classFuncName
+		case t.tok == token.IDENT && predeclared[t.lit]:
+			class = classPredeclare
+		}
+		if class == "" {
+			continue
+		}
+		spans = append(spans, tokenSpan{t.start, t.end, class})
+	}
+	return spans, true
+}
+
+func scanTokens(src string) ([]scanned, bool) {
+	fset := token.NewFileSet()
+	file := fset.AddFile("", fset.Base(), len(src))
+
+	bad := false
+	var s scanner.Scanner
+	s.Init(file, []byte(src), func(token.Position, string) { bad = true }, scanner.ScanComments)
+
+	var toks []scanned
+	for {
+		pos, tok, lit := s.Scan()
+		if tok == token.EOF || bad {
+			break
+		}
+		// Semicolons the scanner inserts at end of line are not in the source.
+		if tok == token.SEMICOLON && lit == "\n" {
+			continue
+		}
+
+		text := lit
+		if text == "" {
+			text = tok.String()
+		}
+		start := file.Offset(pos)
+		end := start + len(text)
+		if tok == token.COMMENT {
+			// Comment literals have carriage returns stripped, so their length
+			// can disagree with the source; measure the delimiters instead.
+			end = commentEnd(src, start)
+		}
+		if start < 0 || start >= len(src) || end <= start {
+			continue
+		}
+		if end > len(src) {
+			end = len(src)
+		}
+		// A literal whose reported length undershot the source would otherwise
+		// leave this token's range running into the previous one.
+		if n := len(toks); n > 0 && toks[n-1].end > start {
+			toks[n-1].end = start
+		}
+		toks = append(toks, scanned{tok, lit, start, end})
+	}
+	if bad {
+		return nil, false
+	}
+	return toks, true
+}
+
+// funcNameIndexes marks the identifiers that name a declared function or
+// method. A declaration's name is the identifier after `func` — or after a
+// parenthesized receiver — and is always followed by the parameter list, or
+// by a type parameter list. That last check is what keeps the return type of
+// a func *type* (`var f func(int) int`) from being mistaken for a name.
+func funcNameIndexes(toks []scanned) map[int]bool {
+	names := map[int]bool{}
+	for i, t := range toks {
+		if t.tok != token.FUNC {
+			continue
+		}
+		j := i + 1
+		if j < len(toks) && toks[j].tok == token.LPAREN {
+			j = skipParens(toks, j)
+		}
+		if j+1 >= len(toks) || toks[j].tok != token.IDENT {
+			continue
+		}
+		if next := toks[j+1].tok; next == token.LPAREN || next == token.LBRACK {
+			names[j] = true
+		}
+	}
+	return names
+}
+
+// skipParens returns the index just past the parenthesis group opening at i.
+func skipParens(toks []scanned, i int) int {
+	depth := 0
+	for ; i < len(toks); i++ {
+		switch toks[i].tok {
+		case token.LPAREN:
+			depth++
+		case token.RPAREN:
+			if depth--; depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return i
+}
+
+// commentEnd returns the offset just past the comment starting at start.
+func commentEnd(src string, start int) int {
+	if strings.HasPrefix(src[start:], "//") {
+		if i := strings.IndexByte(src[start:], '\n'); i >= 0 {
+			return start + i
+		}
+		return len(src)
+	}
+	if i := strings.Index(src[start+2:], "*/"); i >= 0 {
+		return start + 2 + i + 2
+	}
+	return len(src)
+}
+
+// assembleLines walks src once, emitting escaped text and wrapping the spans,
+// and cuts a new line at every newline. Tokens that span lines — raw strings
+// and block comments — are wrapped separately on each line they cover, since
+// every line is its own row in the report.
+func assembleLines(src string, spans []tokenSpan) []template.HTML {
+	out := make([]template.HTML, 0, strings.Count(src, "\n")+1)
+	var b strings.Builder
+
+	emit := func(text, class string) {
+		for {
+			chunk, rest := text, ""
+			cut := false
+			if i := strings.IndexByte(text, '\n'); i >= 0 {
+				chunk, rest, cut = text[:i], text[i+1:], true
+			}
+			if chunk != "" {
+				if class != "" {
+					b.WriteString(`<span class="` + class + `">`)
+				}
+				b.WriteString(template.HTMLEscapeString(chunk))
+				if class != "" {
+					b.WriteString(`</span>`)
+				}
+			}
+			if !cut {
+				return
+			}
+			out = append(out, template.HTML(b.String()))
+			b.Reset()
+			text = rest
+		}
+	}
+
+	off := 0
+	for _, sp := range spans {
+		if sp.start < off {
+			continue
+		}
+		emit(src[off:sp.start], "")
+		emit(src[sp.start:sp.end], sp.class)
+		off = sp.end
+	}
+	emit(src[off:], "")
+	return append(out, template.HTML(b.String()))
+}


### PR DESCRIPTION
**Stack 5/5** — base: #87. This PR was split into a stack; its earlier content now lives in #84 → #85 → #86 → #87, and only the syntax-highlighting commit remains here.

## Summary

Tokenizes each source with `go/scanner` and wraps keywords, strings, numbers, comments, predeclared identifiers and function declaration names in class spans, so the report reads like an editor instead of a wall of monochrome text. Stays stdlib-only and adds no runtime cost — the colours are baked in at render time, with no JavaScript and no external requests.

- Multi-line tokens (raw strings, block comments) are wrapped per line, since each line is its own row carrying a coverage tint.
- A source the scanner cannot read cleanly, or a non-Go file, falls back to plain escaped text with its line count intact — the rows carry the line numbers, so the count must never drift.
- Only *declared* functions and methods get the name colour. A func type looks identical lexically up to its closing paren, so the distinguishing signal is what follows the identifier; that is what keeps the return type in `var f func(int) int` from being coloured as a name.
- The row rule is narrowed to `pre > span` so nested token spans stay inline rather than inheriting the row's `display: block`.
- Colours are defined as CSS variables with a `prefers-color-scheme` dark variant, chosen to stay legible on the green/red coverage tints.

## Test plan

- [x] `TestHighlightLines` — keyword, comment, string, number and predeclared-identifier classes, and HTML escaping of `<` and `&`
- [x] `TestHighlightLinesFuncNames` — methods, generic functions, func types keeping their return type, and func literals having no name
- [x] `TestHighlightLinesMultiLineTokens` — a block comment and a raw string each wrapped separately on every row they cover
- [x] `TestHighlightLinesFallback` — a non-Go file and an unscannable Go source both render escaped with the right line count
- [x] **Round-trip check on the real report**: stripped the token markup back out of all 18 rendered files and compared to the sources — line counts, line numbers and text match exactly, so highlighting introduced no drift
- [x] Verified in headless Chromium that rows compute to `display: block` and tokens to `inline`, in light and dark, on both the full listing and the diff view (`+` gutters and elision separators intact)
- [x] `make build`, `go vet ./...`, `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv