### PR TITLE
Replace Codecov with self-hosted coverage reporting in CI

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -144,9 +144,11 @@ Wait for CI to finish:
 gh pr checks <PR#> --watch
 ```
 
-`codecov/patch` is expected to fail on a release PR — a one-line version bump adds no
-covered code, so the patch has 0% coverage. This is not a blocker; every prior release PR
-hit the same thing. All other checks (test, integration, lint, codecov/project) must pass.
+The `coverage` job posts an informational sticky PR comment (project/patch coverage);
+on a release PR the patch coverage will read n/a or 0% because a one-line version bump
+adds no covered code — expected, and never a blocker since the job doesn't fail on
+percentages. The checks that must pass are test, integration, integration-podman, and
+lint.
 
 Do not merge on your own. Report the CI result to the user and wait for their explicit
 approval — merging is the point of no return for a release. This is a required checkpoint.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,9 @@ name: Test
 on:
   push:
     branches: [ main ]
+  # Every pull request, whatever its base. Restricting this to main would skip
+  # CI entirely on stacked pull requests, which target the branch below them.
   pull_request:
-    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -33,28 +36,108 @@ jobs:
     - name: Download dependencies
       run: go mod download
       
-    - name: Run tests with coverage
-      run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
-      
+    - name: Run tests
+      run: go test -v -race ./...
+
     - name: Build
       run: make build
-      
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage.out
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
-        
+
     - name: Run basic smoke test
       run: |
         ./devgo --help
 
+  # Computes project and patch coverage for pull requests and maintains a
+  # single sticky PR comment with the results, replacing the old Codecov
+  # upload. Informational only: the job never fails on coverage percentages.
+  coverage:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    # A force-push cancels the run for the old head so a stale run can never
+    # overwrite the comment for the new head.
+    concurrency:
+      group: coverage-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-mod-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run tests with coverage (head)
+      run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+    # The base profile is regenerated from the merge-base in a worktree on
+    # every run: slower than caching a baseline, but immune to artifact
+    # expiry and always comparable to the exact commit the PR diffs against.
+    - name: Run tests with coverage (base)
+      run: |
+        BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        echo "BASE=$BASE" >> "$GITHUB_ENV"
+        git worktree add /tmp/base "$BASE"
+        cd /tmp/base
+        go mod download
+        go test -coverprofile="$GITHUB_WORKSPACE/base-coverage.out" -covermode=atomic ./... \
+          || echo "::warning::base tests failed; project delta will be omitted"
+
+    - name: Generate coverage report
+      run: |
+        git diff -U0 "$BASE" HEAD > pr.diff
+        HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+        ARGS="-cover coverage.out -diff pr.diff"
+        ARGS="$ARGS -commit ${HEAD_SHA:0:7}"
+        ARGS="$ARGS -base-name ${{ github.base_ref }}"
+        if [ -s base-coverage.out ]; then
+          ARGS="$ARGS -base-cover base-coverage.out"
+        fi
+        go run ./tools/covreport $ARGS > coverage-report.md
+        cat coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+
+    # Fork PRs have no write token, so the comment step is skipped there;
+    # the report is still visible in the job summary above.
+    - name: Post sticky PR comment
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+          const body = fs.readFileSync('coverage-report.md', 'utf8');
+          const marker = '<!-- devgo-coverage-report -->';
+          const {owner, repo} = context.repo;
+          const issue_number = context.issue.number;
+          const comments = await github.paginate(github.rest.issues.listComments,
+            {owner, repo, issue_number, per_page: 100});
+          const existing = comments.find(c => c.body && c.body.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment(
+              {owner, repo, comment_id: existing.id, body});
+          } else {
+            await github.rest.issues.createComment({owner, repo, issue_number, body});
+          }
+
   integration:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         go-version: ['1.21', '1.22', '1.23', '1.24']

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,10 @@ make help
 
 - **Unit tests**: Test individual packages with mocks
 - **Integration tests**: Test with actual Docker containers and sample devcontainer configs
-- **CI/CD**: GitHub Actions workflow tests on Go 1.20 and 1.21
+- **CI/CD**: GitHub Actions workflow tests on Go 1.21–1.24. A `coverage` job posts a
+  sticky PR comment with project/patch coverage diffs (computed by `tools/covreport`,
+  no external service). For an HTML view, run `make test-coverage` locally and open
+  `coverage.html`.
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint clean install test-integration ci-full help
+.PHONY: build test lint clean install test-coverage test-integration coverage-report dev ci ci-full help
 
 # Default target
 .DEFAULT_GOAL := build
@@ -9,6 +9,7 @@ help:
 	@echo "  test             - Run unit tests"
 	@echo "  test-integration - Run integration tests"
 	@echo "  test-coverage    - Run tests with coverage report"
+	@echo "  coverage-report  - Print markdown coverage summary"
 	@echo "  lint             - Run linter"
 	@echo "  clean            - Clean build artifacts"
 	@echo "  install          - Install binary to GOPATH/bin"
@@ -40,6 +41,10 @@ install:
 test-coverage:
 	go test -v -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
+
+# Print a markdown coverage summary (same tool CI uses for PR comments)
+coverage-report: test-coverage
+	go run ./tools/covreport -cover coverage.out
 
 # Run integration tests
 test-integration:

--- a/README.md
+++ b/README.md
@@ -547,3 +547,41 @@ make dev
 make ci
 ```
 
+### Test Coverage
+
+Coverage is computed in-repo — there is no external coverage service.
+`tools/covreport` reads a `go test -coverprofile` profile and renders it as a
+markdown summary.
+
+```bash
+# Run tests and write coverage.out plus an HTML report
+make test-coverage
+
+# Print the same markdown summary CI posts on pull requests
+make coverage-report
+```
+
+#### What the numbers mean
+
+Both percentages are over Go *statements*, as reported by the coverage
+profile — not over lines or branches.
+
+- **Project coverage** — covered statements ÷ total statements across the
+  whole module. On pull requests it is shown alongside the baseline value and
+  the delta.
+- **Patch coverage** — the same ratio restricted to statements on lines the
+  pull request *adds*. Lines that are only deleted or moved do not count, and
+  a change with no coverable added lines reports `n/a`.
+
+Files that are not production code are excluded from both: `*_test.go`, and
+anything under `test/` or `tools/`.
+
+#### How CI reports it
+
+On every pull request the `coverage` job runs the coverage tests on the head
+commit and on the merge-base, writes the report to the job summary, and
+maintains a **single sticky comment** on the PR that is updated in place on
+each push. The job is informational — it never fails on a coverage
+percentage. Pull requests from forks get the job summary but no comment,
+since they have no write token.
+

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseDiffBytes(t *testing.T) {
+	diff := `diff --git a/cmd/up.go b/cmd/up.go
+--- a/cmd/up.go
++++ b/cmd/up.go
+@@ -10,0 +11,2 @@ func up() {
++	a()
++	b()
+@@ -30 +32 @@ func down() {
++	c()
+diff --git a/cmd/old.go b/cmd/old.go
+--- a/cmd/old.go
++++ /dev/null
+@@ -1,5 +0,0 @@
+diff --git a/cmd/up_test.go b/cmd/up_test.go
+--- a/cmd/up_test.go
++++ b/cmd/up_test.go
+@@ -1,0 +2,3 @@
++ignored
+diff --git a/tools/covreport/main.go b/tools/covreport/main.go
+--- a/tools/covreport/main.go
++++ b/tools/covreport/main.go
+@@ -1,0 +2 @@
++ignored
+diff --git a/pkg/config/config.go b/pkg/config/config.go
+--- a/pkg/config/config.go
++++ b/pkg/config/config.go
+@@ -7,2 +8,0 @@ func load() {
+`
+	got, err := parseDiffBytes([]byte(diff), "test")
+	if err != nil {
+		t.Fatalf("parseDiffBytes returned error: %v", err)
+	}
+	want := map[string][]int{
+		"cmd/up.go": {11, 12, 32},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseDiffBytes = %v, want %v", got, want)
+	}
+	if _, ok := got["pkg/config/config.go"]; ok {
+		t.Error("deletion-only hunk should contribute no added lines")
+	}
+}
+
+func TestParseDiffBytesMalformed(t *testing.T) {
+	diff := "+++ b/cmd/up.go\n@@ nonsense @@\n"
+	_, err := parseDiffBytes([]byte(diff), "mysource")
+	if err == nil {
+		t.Fatal("expected an error for a malformed hunk header")
+	}
+	if !strings.Contains(err.Error(), "mysource") {
+		t.Errorf("error %q should name the diff source", err)
+	}
+}
+
+func TestParseHunkHeader(t *testing.T) {
+	tests := []struct {
+		line      string
+		wantStart int
+		wantCount int
+	}{
+		{"@@ -1 +1 @@", 1, 1},
+		{"@@ -11,0 +12 @@ help:", 12, 1},
+		{"@@ -42 +43,5 @@ test-coverage:", 43, 5},
+		{"@@ -7,2 +8,0 @@", 8, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			start, count, err := parseHunkHeader(tt.line)
+			if err != nil {
+				t.Fatalf("parseHunkHeader returned error: %v", err)
+			}
+			if start != tt.wantStart || count != tt.wantCount {
+				t.Errorf("got (%d, %d), want (%d, %d)",
+					start, count, tt.wantStart, tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestCompressRanges(t *testing.T) {
+	tests := []struct {
+		name  string
+		lines []int
+		want  string
+	}{
+		{"empty", nil, ""},
+		{"single", []int{7}, "7"},
+		{"run", []int{12, 13, 14, 15}, "12-15"},
+		{"mixed", []int{12, 13, 14, 15, 22}, "12-15, 22"},
+		{"pairs", []int{1, 2, 5, 6}, "1-2, 5-6"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compressRanges(tt.lines); got != tt.want {
+				t.Errorf("compressRanges(%v) = %q, want %q", tt.lines, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPatchCoverageDropsEmptyFiles(t *testing.T) {
+	const module = "example.com/m"
+	head := profile{
+		module + "/cmd/a.go": {{startLine: 10, endLine: 12, numStmts: 2, count: 1}},
+	}
+	added := map[string][]int{"cmd/a.go": {11}, "cmd/b.go": {3}}
+
+	stats := patchCoverage(head, added, module)
+	if len(stats) != 1 || stats[0].file != "cmd/a.go" {
+		t.Fatalf("patchCoverage = %+v, want only cmd/a.go", stats)
+	}
+}

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -116,5 +119,177 @@ func TestPatchCoverageDropsEmptyFiles(t *testing.T) {
 	stats := patchCoverage(head, added, module)
 	if len(stats) != 1 || stats[0].file != "cmd/a.go" {
 		t.Fatalf("patchCoverage = %+v, want only cmd/a.go", stats)
+	}
+}
+
+func TestParseProfileLine(t *testing.T) {
+	tests := []struct {
+		name      string
+		line      string
+		wantFile  string
+		wantBlock block
+	}{
+		{
+			name:     "covered block",
+			line:     "github.com/garaemon/devgo/pkg/config/config.go:58.39,59.52 1 1",
+			wantFile: "github.com/garaemon/devgo/pkg/config/config.go",
+			wantBlock: block{
+				startLine: 58, endLine: 59, numStmts: 1, count: 1,
+			},
+		},
+		{
+			name:     "uncovered block keeps its statement count",
+			line:     "example.com/m/cmd/up.go:41.24,49.16 5 0",
+			wantFile: "example.com/m/cmd/up.go",
+			wantBlock: block{
+				startLine: 41, endLine: 49, numStmts: 5, count: 0,
+			},
+		},
+		{
+			name:     "count mode records real execution counts",
+			line:     "example.com/m/cmd/up.go:10.2,10.20 1 47",
+			wantFile: "example.com/m/cmd/up.go",
+			wantBlock: block{
+				startLine: 10, endLine: 10, numStmts: 1, count: 47,
+			},
+		},
+		{
+			// A module path may carry a port, so the position has to be split
+			// off at the last colon rather than the first.
+			name:     "module path containing a colon",
+			line:     "localhost:8080/m/cmd/up.go:3.1,4.2 2 1",
+			wantFile: "localhost:8080/m/cmd/up.go",
+			wantBlock: block{
+				startLine: 3, endLine: 4, numStmts: 2, count: 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, gotBlock, err := parseProfileLine(tt.line)
+			if err != nil {
+				t.Fatalf("parseProfileLine(%q) returned error: %v", tt.line, err)
+			}
+			if file != tt.wantFile {
+				t.Errorf("file = %q, want %q", file, tt.wantFile)
+			}
+			if gotBlock != tt.wantBlock {
+				t.Errorf("block = %+v, want %+v", gotBlock, tt.wantBlock)
+			}
+		})
+	}
+}
+
+func TestParseProfileLineMalformed(t *testing.T) {
+	lines := []string{
+		"",
+		"mode set",
+		"example.com/m/cmd/up.go 1.2,3.4 5 6",
+		"example.com/m/cmd/up.go:1.2,3.4 5",
+		"example.com/m/cmd/up.go:1.2,3.4 x 6",
+		"example.com/m/cmd/up.go:1-2,3-4 5 6",
+	}
+	for _, line := range lines {
+		if _, _, err := parseProfileLine(line); err == nil {
+			t.Errorf("parseProfileLine(%q) = nil error, want a malformed-line error", line)
+		}
+	}
+}
+
+func TestParseProfile(t *testing.T) {
+	const module = "example.com/m"
+	// Blocks of one file are not necessarily contiguous, the header and blank
+	// lines carry no data, and tooling and test sources are not coverable.
+	text := `mode: set
+example.com/m/cmd/up.go:41.24,49.16 5 1
+example.com/m/pkg/config/config.go:58.39,59.52 1 1
+example.com/m/cmd/up.go:49.16,51.4 1 0
+example.com/m/cmd/up_test.go:7.13,9.2 1 1
+example.com/m/tools/covreport/main.go:12.20,14.3 2 1
+
+`
+	path := filepath.Join(t.TempDir(), "coverage.out")
+	if err := os.WriteFile(path, []byte(text), 0o600); err != nil {
+		t.Fatalf("writing the profile: %v", err)
+	}
+
+	got, err := parseProfile(path, module)
+	if err != nil {
+		t.Fatalf("parseProfile returned error: %v", err)
+	}
+	want := profile{
+		module + "/cmd/up.go": {
+			{startLine: 41, endLine: 49, numStmts: 5, count: 1},
+			{startLine: 49, endLine: 51, numStmts: 1, count: 0},
+		},
+		module + "/pkg/config/config.go": {
+			{startLine: 58, endLine: 59, numStmts: 1, count: 1},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("parseProfile = %+v, want %+v", got, want)
+	}
+
+	if total := totalTally(got); total.covered != 6 || total.total != 7 {
+		t.Errorf("totalTally = %+v, want 6 covered of 7", total)
+	}
+}
+
+func TestParseProfileModesAgree(t *testing.T) {
+	const module = "example.com/m"
+	const blocks = `example.com/m/cmd/up.go:41.24,49.16 5 1
+example.com/m/cmd/up.go:49.16,51.4 1 0
+`
+	dir := t.TempDir()
+
+	// "set" writes 0/1 while "count" and "atomic" write real counts; covreport
+	// only asks whether the count is nonzero, so all three tally alike.
+	var first tally
+	for index, header := range []string{"mode: set\n", "mode: count\n", "mode: atomic\n"} {
+		text := header + blocks
+		if strings.HasPrefix(header, "mode: count") ||
+			strings.HasPrefix(header, "mode: atomic") {
+			text = header + strings.Replace(blocks, "5 1", "5 12", 1)
+		}
+		path := filepath.Join(dir, fmt.Sprintf("coverage%d.out", index))
+		if err := os.WriteFile(path, []byte(text), 0o600); err != nil {
+			t.Fatalf("writing the profile: %v", err)
+		}
+		parsed, err := parseProfile(path, module)
+		if err != nil {
+			t.Fatalf("parseProfile(%q) returned error: %v", header, err)
+		}
+		total := totalTally(parsed)
+		if index == 0 {
+			first = total
+			continue
+		}
+		if total != first {
+			t.Errorf("%q tallied %+v, want %+v as in mode: set", header, total, first)
+		}
+	}
+}
+
+func TestParseProfileMalformedNamesTheLine(t *testing.T) {
+	text := "mode: set\nexample.com/m/cmd/up.go:41.24,49.16 5 1\nnonsense\n"
+	path := filepath.Join(t.TempDir(), "coverage.out")
+	if err := os.WriteFile(path, []byte(text), 0o600); err != nil {
+		t.Fatalf("writing the profile: %v", err)
+	}
+
+	_, err := parseProfile(path, "example.com/m")
+	if err == nil {
+		t.Fatal("expected an error for a malformed profile line")
+	}
+	if !strings.Contains(err.Error(), path+":3") {
+		t.Errorf("error %q should name the profile and the line number", err)
+	}
+}
+
+func TestParseProfileMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "absent.out")
+	if _, err := parseProfile(path, "example.com/m"); err == nil {
+		t.Fatal("expected an error for a profile that does not exist")
 	}
 }

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -231,8 +231,8 @@ example.com/m/tools/covreport/main.go:12.20,14.3 2 1
 		t.Errorf("parseProfile = %+v, want %+v", got, want)
 	}
 
-	if total := totalTally(got); total.covered != 6 || total.total != 7 {
-		t.Errorf("totalTally = %+v, want 6 covered of 7", total)
+	if total := aggregateTotal(got); total.covered != 6 || total.total != 7 {
+		t.Errorf("aggregateTotal = %+v, want 6 covered of 7", total)
 	}
 }
 
@@ -260,7 +260,7 @@ example.com/m/cmd/up.go:49.16,51.4 1 0
 		if err != nil {
 			t.Fatalf("parseProfile(%q) returned error: %v", header, err)
 		}
-		total := totalTally(parsed)
+		total := aggregateTotal(parsed)
 		if index == 0 {
 			first = total
 			continue

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -74,15 +74,15 @@ func TestParseHunkHeader(t *testing.T) {
 		{"@@ -42 +43,5 @@ test-coverage:", 43, 5},
 		{"@@ -7,2 +8,0 @@", 8, 0},
 	}
-	for _, tt := range tests {
-		t.Run(tt.line, func(t *testing.T) {
-			start, count, err := parseHunkHeader(tt.line)
+	for _, testCase := range tests {
+		t.Run(testCase.line, func(t *testing.T) {
+			start, count, err := parseHunkHeader(testCase.line)
 			if err != nil {
 				t.Fatalf("parseHunkHeader returned error: %v", err)
 			}
-			if start != tt.wantStart || count != tt.wantCount {
+			if start != testCase.wantStart || count != testCase.wantCount {
 				t.Errorf("got (%d, %d), want (%d, %d)",
-					start, count, tt.wantStart, tt.wantCount)
+					start, count, testCase.wantStart, testCase.wantCount)
 			}
 		})
 	}
@@ -100,10 +100,10 @@ func TestCompressRanges(t *testing.T) {
 		{"mixed", []int{12, 13, 14, 15, 22}, "12-15, 22"},
 		{"pairs", []int{1, 2, 5, 6}, "1-2, 5-6"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := compressRanges(tt.lines); got != tt.want {
-				t.Errorf("compressRanges(%v) = %q, want %q", tt.lines, got, tt.want)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := compressRanges(testCase.lines); got != testCase.want {
+				t.Errorf("compressRanges(%v) = %q, want %q", testCase.lines, got, testCase.want)
 			}
 		})
 	}
@@ -165,17 +165,17 @@ func TestParseProfileLine(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			file, gotBlock, err := parseProfileLine(tt.line)
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			file, gotBlock, err := parseProfileLine(testCase.line)
 			if err != nil {
-				t.Fatalf("parseProfileLine(%q) returned error: %v", tt.line, err)
+				t.Fatalf("parseProfileLine(%q) returned error: %v", testCase.line, err)
 			}
-			if file != tt.wantFile {
-				t.Errorf("file = %q, want %q", file, tt.wantFile)
+			if file != testCase.wantFile {
+				t.Errorf("file = %q, want %q", file, testCase.wantFile)
 			}
-			if gotBlock != tt.wantBlock {
-				t.Errorf("block = %+v, want %+v", gotBlock, tt.wantBlock)
+			if gotBlock != testCase.wantBlock {
+				t.Errorf("block = %+v, want %+v", gotBlock, testCase.wantBlock)
 			}
 		})
 	}

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -109,16 +109,16 @@ func TestCompressRanges(t *testing.T) {
 	}
 }
 
-func TestPatchCoverageDropsEmptyFiles(t *testing.T) {
+func TestAggregatePatchByFileDropsEmptyFiles(t *testing.T) {
 	const module = "example.com/m"
 	head := profile{
 		module + "/cmd/a.go": {{startLine: 10, endLine: 12, numStmts: 2, count: 1}},
 	}
 	added := map[string][]int{"cmd/a.go": {11}, "cmd/b.go": {3}}
 
-	stats := patchCoverage(head, added, module)
+	stats := aggregatePatchByFile(head, added, module)
 	if len(stats) != 1 || stats[0].file != "cmd/a.go" {
-		t.Fatalf("patchCoverage = %+v, want only cmd/a.go", stats)
+		t.Fatalf("aggregatePatchByFile = %+v, want only cmd/a.go", stats)
 	}
 }
 

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -243,6 +243,16 @@ func parseDiffBytes(data []byte, source string) (map[string][]int, error) {
 	return added, nil
 }
 
+// coverableFile reports whether a repository-relative path is one whose
+// coverage the report should account for. It is the single definition of
+// "code that counts", applied to both inputs — profile entries and diff
+// hunks — so a file can never be counted on one side and missing on the
+// other, which would make patch coverage disagree with the project total.
+//
+// Excluded are non-Go files, which have no statements to cover; test sources
+// (`_test.go` and everything under `test/`), which are the tests themselves
+// rather than the code under test; and `tools/`, whose helpers — covreport
+// among them — support the build rather than ship in the binary.
 func coverableFile(name string) bool {
 	return strings.HasSuffix(name, ".go") &&
 		!strings.HasSuffix(name, "_test.go") &&
@@ -276,6 +286,15 @@ func parseHunkHeader(line string) (startLine, lineCount int, err error) {
 	return 0, 0, fmt.Errorf("malformed hunk header %q", line)
 }
 
+// tally is a running count of statements over some scope — a file, a package,
+// a patch or the whole project — used for every percentage in the report.
+//
+// The unit is statements, not lines, because that is what the profile counts:
+// each block carries a statement count, and a block either ran or it did not.
+// So total is the statements seen and covered the subset in blocks that ran,
+// which makes coverage the ratio of the two and keeps a dense one-liner worth
+// more than a line of punctuation. A tally with total 0 means nothing
+// coverable was in scope, and reports as "n/a" rather than 0%.
 type tally struct {
 	covered int
 	total   int
@@ -288,6 +307,9 @@ func (counts tally) percent() float64 {
 	return 100 * float64(counts.covered) / float64(counts.total)
 }
 
+// add folds one coverage block into the tally. A block counts as covered in
+// full or not at all, since the profile records a single execution count for
+// all of its statements.
 func (counts *tally) add(coverageBlock block) {
 	counts.total += coverageBlock.numStmts
 	if coverageBlock.count > 0 {

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -317,8 +317,8 @@ func (counts *tally) add(coverageBlock block) {
 	}
 }
 
-// perPackage aggregates a profile into per-package statement tallies.
-func perPackage(coverage profile) map[string]tally {
+// aggregateByPackage sums a profile into one statement tally per package.
+func aggregateByPackage(coverage profile) map[string]tally {
 	packages := map[string]tally{}
 	for file, blocks := range coverage {
 		packageName := path.Dir(file)
@@ -331,7 +331,9 @@ func perPackage(coverage profile) map[string]tally {
 	return packages
 }
 
-func totalTally(coverage profile) tally {
+// aggregateTotal sums a profile into a single statement tally for the whole
+// module.
+func aggregateTotal(coverage profile) tally {
 	var total tally
 	for _, blocks := range coverage {
 		for _, coverageBlock := range blocks {
@@ -450,10 +452,10 @@ func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
 		fmt.Fprintf(&report, "Commit: `%s`\n\n", commit)
 	}
 
-	headTotal := totalTally(head)
+	headTotal := aggregateTotal(head)
 	projectLine := fmt.Sprintf("**Project:** %.1f%%", headTotal.percent())
 	if base != nil {
-		baseTotal := totalTally(base)
+		baseTotal := aggregateTotal(base)
 		delta := headTotal.percent() - baseTotal.percent()
 		projectLine += fmt.Sprintf(" (%s: %.1f%%, %+.1f%%)", baseName, baseTotal.percent(), delta)
 	}
@@ -498,8 +500,8 @@ func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
 }
 
 func writePackageDelta(report *strings.Builder, head, base profile, module, baseName string) {
-	headPackages := perPackage(head)
-	basePackages := perPackage(base)
+	headPackages := aggregateByPackage(head)
+	basePackages := aggregateByPackage(base)
 	seenPackages := map[string]bool{}
 	for packageName := range headPackages {
 		seenPackages[packageName] = true

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -402,6 +402,9 @@ func aggregatePatchByFile(head profile, added map[string][]int, module string) [
 	return stats
 }
 
+// dedupInts removes adjacent duplicates from a sorted slice, compacting in
+// place: it overwrites sorted's backing array, so the caller's slice is left
+// with stale values past the returned length. Pass a slice you own.
 func dedupInts(sorted []int) []int {
 	deduped := sorted[:0]
 	previous := -1

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -93,9 +93,34 @@ func moduleFromGoMod(path string) (string, error) {
 	return "", fmt.Errorf("no module directive in %s", path)
 }
 
-// parseProfile reads a coverage profile, dropping files that are not
-// coverable (tooling under tools/). Each line after the "mode:" header
-// looks like: name.go:startLine.startCol,endLine.endCol numStmts count
+// A coverage profile is the text file written by go test -coverprofile. The
+// first line is a mode header and every line after it describes one coverage
+// block:
+//
+//	mode: set
+//	github.com/garaemon/devgo/pkg/config/config.go:58.39,59.52 1 1
+//	github.com/garaemon/devgo/pkg/config/config.go:59.52,61.3 1 0
+//
+// A block line has the shape
+//
+//	<import path>/<file>.go:<startLine>.<startCol>,<endLine>.<endCol> <numStmts> <count>
+//
+// where numStmts is how many statements the block contains and count is how
+// often it ran, so 0 means uncovered. The header says what count means: under
+// "set" it is only 0 or 1, while "count" and "atomic" hold real execution
+// counts. This tool only asks whether count is nonzero, so all three modes
+// parse identically and the header is skipped.
+//
+// A block is a straight-line run of statements rather than a line range,
+// which is why the positions carry columns and why a block can begin and end
+// part-way through a line — above, line 59 ends the first block and starts
+// the second. covreport works at line granularity and ignores the columns, so
+// a single line may belong to several blocks. Blocks for one file are not
+// guaranteed to be contiguous in the profile either, hence the append below
+// rather than a single assignment.
+//
+// parseProfile reads such a profile, dropping files that are not coverable
+// (tooling under tools/).
 func parseProfile(path, module string) (profile, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -120,6 +145,9 @@ func parseProfile(path, module string) (profile, error) {
 	return p, nil
 }
 
+// parseProfileLine splits one block line into its file name and block. The
+// name is taken as everything before the *last* colon: it is a full import
+// path, so only the trailing position field has a fixed shape.
 func parseProfileLine(line string) (string, block, error) {
 	colon := strings.LastIndex(line, ":")
 	if colon < 0 {

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -1,0 +1,474 @@
+// Command covreport turns Go coverage profiles into a markdown coverage
+// report for pull requests: overall ("project") coverage with an optional
+// delta against a base profile, and "patch" coverage over the lines added
+// by a diff. It replaces the Codecov project/patch statuses with a report
+// built entirely from go test -coverprofile output.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// block is one record from a coverage profile: a range of source lines with
+// a statement count and how many times those statements ran.
+type block struct {
+	startLine int
+	endLine   int
+	numStmts  int
+	count     int
+}
+
+// profile maps a module-path-qualified file name (as it appears in the
+// profile, e.g. github.com/garaemon/devgo/pkg/config/config.go) to its
+// coverage blocks.
+type profile map[string][]block
+
+func main() {
+	coverPath := flag.String("cover", "", "head coverage profile (required)")
+	baseCoverPath := flag.String("base-cover", "", "base coverage profile for the project delta")
+	diffPath := flag.String("diff", "", "unified diff (git diff -U0) for patch coverage")
+	module := flag.String("module", "", "module path (default: read from go.mod)")
+	commit := flag.String("commit", "", "head commit SHA to show in the report")
+	baseName := flag.String("base-name", "main", "display name of the base branch")
+	flag.Parse()
+
+	if *coverPath == "" {
+		fmt.Fprintln(os.Stderr, "covreport: -cover is required")
+		os.Exit(2)
+	}
+	if *module == "" {
+		m, err := moduleFromGoMod("go.mod")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "covreport: cannot determine module path: %v\n", err)
+			os.Exit(2)
+		}
+		*module = m
+	}
+
+	head, err := parseProfile(*coverPath, *module)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+		os.Exit(1)
+	}
+
+	var base profile
+	if *baseCoverPath != "" {
+		base, err = parseProfile(*baseCoverPath, *module)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	var added map[string][]int
+	haveDiff := false
+	if *diffPath != "" {
+		added, err = parseDiff(*diffPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+			os.Exit(1)
+		}
+		haveDiff = true
+	}
+
+	fmt.Print(renderMarkdown(head, base, added, haveDiff, *module, *commit, *baseName))
+}
+
+func moduleFromGoMod(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "module "); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", fmt.Errorf("no module directive in %s", path)
+}
+
+// parseProfile reads a coverage profile, dropping files that are not
+// coverable (tooling under tools/). Each line after the "mode:" header
+// looks like: name.go:startLine.startCol,endLine.endCol numStmts count
+func parseProfile(path, module string) (profile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	p := profile{}
+	for i, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "mode:") {
+			continue
+		}
+		file, b, err := parseProfileLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("%s:%d: %v", path, i+1, err)
+		}
+		if !coverableFile(strings.TrimPrefix(file, module+"/")) {
+			continue
+		}
+		p[file] = append(p[file], b)
+	}
+	return p, nil
+}
+
+func parseProfileLine(line string) (string, block, error) {
+	colon := strings.LastIndex(line, ":")
+	if colon < 0 {
+		return "", block{}, fmt.Errorf("malformed profile line %q", line)
+	}
+	file := line[:colon]
+	var sl, sc, el, ec, stmts, count int
+	n, err := fmt.Sscanf(line[colon+1:], "%d.%d,%d.%d %d %d", &sl, &sc, &el, &ec, &stmts, &count)
+	if err != nil || n != 6 {
+		return "", block{}, fmt.Errorf("malformed profile line %q", line)
+	}
+	return file, block{startLine: sl, endLine: el, numStmts: stmts, count: count}, nil
+}
+
+// parseDiff extracts the added-line numbers per new-side file path from a
+// unified diff. Only non-test .go files outside test/ are kept.
+func parseDiff(path string) (map[string][]int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return parseDiffBytes(data, path)
+}
+
+// parseDiffBytes is parseDiff over an in-memory diff; source only names the
+// input in error messages.
+func parseDiffBytes(data []byte, source string) (map[string][]int, error) {
+	added := map[string][]int{}
+	current := ""
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case strings.HasPrefix(line, "+++ "):
+			current = ""
+			name := strings.TrimSpace(strings.TrimPrefix(line, "+++ "))
+			if i := strings.IndexByte(name, '\t'); i >= 0 {
+				name = name[:i]
+			}
+			if name == "/dev/null" {
+				continue
+			}
+			name = strings.TrimPrefix(name, "b/")
+			if coverableFile(name) {
+				current = name
+			}
+		case strings.HasPrefix(line, "@@ ") && current != "":
+			start, count, err := parseHunkHeader(line)
+			if err != nil {
+				return nil, fmt.Errorf("%s: %v", source, err)
+			}
+			for i := 0; i < count; i++ {
+				added[current] = append(added[current], start+i)
+			}
+		}
+	}
+	return added, nil
+}
+
+func coverableFile(name string) bool {
+	return strings.HasSuffix(name, ".go") &&
+		!strings.HasSuffix(name, "_test.go") &&
+		!strings.HasPrefix(name, "test/") &&
+		!strings.HasPrefix(name, "tools/")
+}
+
+// parseHunkHeader returns the new-side start line and line count from a
+// "@@ -a,b +c,d @@" header ("+c" alone means one line, "+c,0" means none).
+func parseHunkHeader(line string) (start, count int, err error) {
+	fields := strings.Fields(line)
+	for _, f := range fields {
+		if !strings.HasPrefix(f, "+") {
+			continue
+		}
+		spec := strings.TrimPrefix(f, "+")
+		count = 1
+		if i := strings.IndexByte(spec, ','); i >= 0 {
+			count, err = strconv.Atoi(spec[i+1:])
+			if err != nil {
+				return 0, 0, fmt.Errorf("malformed hunk header %q", line)
+			}
+			spec = spec[:i]
+		}
+		start, err = strconv.Atoi(spec)
+		if err != nil {
+			return 0, 0, fmt.Errorf("malformed hunk header %q", line)
+		}
+		return start, count, nil
+	}
+	return 0, 0, fmt.Errorf("malformed hunk header %q", line)
+}
+
+type tally struct {
+	covered int
+	total   int
+}
+
+func (t tally) percent() float64 {
+	if t.total == 0 {
+		return 0
+	}
+	return 100 * float64(t.covered) / float64(t.total)
+}
+
+func (t *tally) add(b block) {
+	t.total += b.numStmts
+	if b.count > 0 {
+		t.covered += b.numStmts
+	}
+}
+
+// perPackage aggregates a profile into per-package statement tallies.
+func perPackage(p profile) map[string]tally {
+	pkgs := map[string]tally{}
+	for file, blocks := range p {
+		pkg := path.Dir(file)
+		t := pkgs[pkg]
+		for _, b := range blocks {
+			t.add(b)
+		}
+		pkgs[pkg] = t
+	}
+	return pkgs
+}
+
+func totalTally(p profile) tally {
+	var t tally
+	for _, blocks := range p {
+		for _, b := range blocks {
+			t.add(b)
+		}
+	}
+	return t
+}
+
+// patchTally computes per-file patch coverage: statements of blocks that
+// overlap added lines, and how many of those statements ran.
+type fileStat struct {
+	file      string
+	t         tally
+	uncovered []int
+}
+
+func patchCoverage(head profile, added map[string][]int, module string) []fileStat {
+	var stats []fileStat
+	files := make([]string, 0, len(added))
+	for f := range added {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+
+	for _, file := range files {
+		lines := added[file]
+		lineSet := map[int]bool{}
+		for _, l := range lines {
+			lineSet[l] = true
+		}
+		blocks := head[module+"/"+file]
+		var st fileStat
+		st.file = file
+		for _, b := range blocks {
+			touched := false
+			for l := b.startLine; l <= b.endLine; l++ {
+				if lineSet[l] {
+					touched = true
+					break
+				}
+			}
+			if !touched {
+				continue
+			}
+			st.t.add(b)
+			if b.count == 0 {
+				for l := b.startLine; l <= b.endLine; l++ {
+					if lineSet[l] {
+						st.uncovered = append(st.uncovered, l)
+					}
+				}
+			}
+		}
+		if st.t.total > 0 {
+			sort.Ints(st.uncovered)
+			st.uncovered = dedupInts(st.uncovered)
+			stats = append(stats, st)
+		}
+	}
+	return stats
+}
+
+func dedupInts(s []int) []int {
+	out := s[:0]
+	prev := -1
+	for _, v := range s {
+		if v != prev {
+			out = append(out, v)
+		}
+		prev = v
+	}
+	return out
+}
+
+// compressRanges renders sorted line numbers as "12-15, 22".
+func compressRanges(lines []int) string {
+	if len(lines) == 0 {
+		return ""
+	}
+	var parts []string
+	start, end := lines[0], lines[0]
+	flush := func() {
+		if start == end {
+			parts = append(parts, strconv.Itoa(start))
+		} else {
+			parts = append(parts, fmt.Sprintf("%d-%d", start, end))
+		}
+	}
+	for _, l := range lines[1:] {
+		if l == end+1 {
+			end = l
+			continue
+		}
+		flush()
+		start, end = l, l
+	}
+	flush()
+	return strings.Join(parts, ", ")
+}
+
+func shortPkg(pkg, module string) string {
+	if pkg == module {
+		return "."
+	}
+	return strings.TrimPrefix(pkg, module+"/")
+}
+
+func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
+	module, commit, baseName string) string {
+	var b strings.Builder
+	b.WriteString("<!-- devgo-coverage-report -->\n")
+	b.WriteString("## Coverage report\n\n")
+	if commit != "" {
+		fmt.Fprintf(&b, "Commit: `%s`\n\n", commit)
+	}
+
+	headTotal := totalTally(head)
+	projectLine := fmt.Sprintf("**Project:** %.1f%%", headTotal.percent())
+	if base != nil {
+		baseTotal := totalTally(base)
+		delta := headTotal.percent() - baseTotal.percent()
+		projectLine += fmt.Sprintf(" (%s: %.1f%%, %+.1f%%)", baseName, baseTotal.percent(), delta)
+	}
+
+	patchLine := ""
+	var patchStats []fileStat
+	if haveDiff {
+		patchStats = patchCoverage(head, added, module)
+		var patchTotal tally
+		for _, st := range patchStats {
+			patchTotal.covered += st.t.covered
+			patchTotal.total += st.t.total
+		}
+		if patchTotal.total == 0 {
+			patchLine = "**Patch:** n/a (no coverable changes)"
+		} else {
+			patchLine = fmt.Sprintf("**Patch:** %.1f%% (%d/%d statements)",
+				patchTotal.percent(), patchTotal.covered, patchTotal.total)
+		}
+	}
+
+	b.WriteString(projectLine)
+	if patchLine != "" {
+		b.WriteString(" &nbsp;&nbsp; " + patchLine)
+	}
+	b.WriteString("\n\n")
+	if base == nil {
+		b.WriteString("_Baseline unavailable — project delta omitted._\n\n")
+	}
+
+	if base != nil {
+		writePackageDelta(&b, head, base, module, baseName)
+	}
+	if len(patchStats) > 0 {
+		writePatchTable(&b, patchStats)
+	}
+
+	b.WriteString("---\n")
+	b.WriteString("To browse the full HTML report locally, check out this branch and run " +
+		"`make test-coverage`, then open `coverage.html`.\n")
+	return b.String()
+}
+
+func writePackageDelta(b *strings.Builder, head, base profile, module, baseName string) {
+	headPkgs := perPackage(head)
+	basePkgs := perPackage(base)
+	pkgSet := map[string]bool{}
+	for p := range headPkgs {
+		pkgSet[p] = true
+	}
+	for p := range basePkgs {
+		pkgSet[p] = true
+	}
+	pkgs := make([]string, 0, len(pkgSet))
+	for p := range pkgSet {
+		pkgs = append(pkgs, p)
+	}
+	sort.Strings(pkgs)
+
+	type row struct {
+		name     string
+		headPct  string
+		basePct  string
+		deltaPct string
+	}
+	var rows []row
+	for _, p := range pkgs {
+		ht, inHead := headPkgs[p]
+		bt, inBase := basePkgs[p]
+		switch {
+		case inHead && !inBase:
+			rows = append(rows, row{shortPkg(p, module),
+				fmt.Sprintf("%.1f%%", ht.percent()), "—", "new"})
+		case !inHead && inBase:
+			rows = append(rows, row{shortPkg(p, module),
+				"—", fmt.Sprintf("%.1f%%", bt.percent()), "removed"})
+		case ht.percent() != bt.percent():
+			rows = append(rows, row{shortPkg(p, module),
+				fmt.Sprintf("%.1f%%", ht.percent()),
+				fmt.Sprintf("%.1f%%", bt.percent()),
+				fmt.Sprintf("%+.1f%%", ht.percent()-bt.percent())})
+		}
+	}
+	if len(rows) == 0 {
+		b.WriteString("_No per-package coverage changes._\n\n")
+		return
+	}
+
+	b.WriteString("<details>\n<summary>Per-package coverage changes</summary>\n\n")
+	fmt.Fprintf(b, "| Package | HEAD | %s | Δ |\n", baseName)
+	b.WriteString("| --- | ---: | ---: | ---: |\n")
+	for _, r := range rows {
+		fmt.Fprintf(b, "| %s | %s | %s | %s |\n", r.name, r.headPct, r.basePct, r.deltaPct)
+	}
+	b.WriteString("\n</details>\n\n")
+}
+
+func writePatchTable(b *strings.Builder, stats []fileStat) {
+	b.WriteString("<details>\n<summary>Patch coverage by file</summary>\n\n")
+	b.WriteString("| File | Coverage | Statements | Uncovered new lines |\n")
+	b.WriteString("| --- | ---: | ---: | --- |\n")
+	for _, st := range stats {
+		fmt.Fprintf(b, "| %s | %.1f%% | %d/%d | %s |\n",
+			st.file, st.t.percent(), st.t.covered, st.t.total, compressRanges(st.uncovered))
+	}
+	b.WriteString("\n</details>\n\n")
+}

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -352,7 +352,11 @@ type fileStat struct {
 	uncovered []int
 }
 
-func patchCoverage(head profile, added map[string][]int, module string) []fileStat {
+// aggregatePatchByFile sums the head profile over the added lines of each
+// changed file, in path order. A file is included only when the added lines
+// touch at least one coverable statement, so renames, comment-only edits and
+// changes to non-Go files leave no empty rows in the report.
+func aggregatePatchByFile(head profile, added map[string][]int, module string) []fileStat {
 	var stats []fileStat
 	files := make([]string, 0, len(added))
 	for file := range added {
@@ -463,7 +467,7 @@ func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
 	patchLine := ""
 	var patchStats []fileStat
 	if haveDiff {
-		patchStats = patchCoverage(head, added, module)
+		patchStats = aggregatePatchByFile(head, added, module)
 		var patchTotal tally
 		for _, stat := range patchStats {
 			patchTotal.covered += stat.coverage.covered

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -43,12 +43,12 @@ func main() {
 		os.Exit(2)
 	}
 	if *module == "" {
-		m, err := moduleFromGoMod("go.mod")
+		modulePath, err := moduleFromGoMod("go.mod")
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "covreport: cannot determine module path: %v\n", err)
 			os.Exit(2)
 		}
-		*module = m
+		*module = modulePath
 	}
 
 	head, err := parseProfile(*coverPath, *module)
@@ -80,8 +80,8 @@ func main() {
 	fmt.Print(renderMarkdown(head, base, added, haveDiff, *module, *commit, *baseName))
 }
 
-func moduleFromGoMod(path string) (string, error) {
-	data, err := os.ReadFile(path)
+func moduleFromGoMod(goModPath string) (string, error) {
+	data, err := os.ReadFile(goModPath)
 	if err != nil {
 		return "", err
 	}
@@ -90,7 +90,7 @@ func moduleFromGoMod(path string) (string, error) {
 			return strings.TrimSpace(rest), nil
 		}
 	}
-	return "", fmt.Errorf("no module directive in %s", path)
+	return "", fmt.Errorf("no module directive in %s", goModPath)
 }
 
 // A coverage profile is the text file written by go test -coverprofile. The
@@ -121,84 +121,122 @@ func moduleFromGoMod(path string) (string, error) {
 //
 // parseProfile reads such a profile, dropping files that are not coverable
 // (tooling under tools/).
-func parseProfile(path, module string) (profile, error) {
-	data, err := os.ReadFile(path)
+func parseProfile(profilePath, module string) (profile, error) {
+	data, err := os.ReadFile(profilePath)
 	if err != nil {
 		return nil, err
 	}
 
-	p := profile{}
-	for i, line := range strings.Split(string(data), "\n") {
+	coverageByFile := profile{}
+	for lineIndex, line := range strings.Split(string(data), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "mode:") {
 			continue
 		}
-		file, b, err := parseProfileLine(line)
+		file, coverageBlock, err := parseProfileLine(line)
 		if err != nil {
-			return nil, fmt.Errorf("%s:%d: %v", path, i+1, err)
+			return nil, fmt.Errorf("%s:%d: %v", profilePath, lineIndex+1, err)
 		}
 		if !coverableFile(strings.TrimPrefix(file, module+"/")) {
 			continue
 		}
-		p[file] = append(p[file], b)
+		coverageByFile[file] = append(coverageByFile[file], coverageBlock)
 	}
-	return p, nil
+	return coverageByFile, nil
 }
 
 // parseProfileLine splits one block line into its file name and block. The
 // name is taken as everything before the *last* colon: it is a full import
 // path, so only the trailing position field has a fixed shape.
 func parseProfileLine(line string) (string, block, error) {
-	colon := strings.LastIndex(line, ":")
-	if colon < 0 {
+	lastColon := strings.LastIndex(line, ":")
+	if lastColon < 0 {
 		return "", block{}, fmt.Errorf("malformed profile line %q", line)
 	}
-	file := line[:colon]
-	var sl, sc, el, ec, stmts, count int
-	n, err := fmt.Sscanf(line[colon+1:], "%d.%d,%d.%d %d %d", &sl, &sc, &el, &ec, &stmts, &count)
-	if err != nil || n != 6 {
+	file := line[:lastColon]
+	var startLine, startCol, endLine, endCol, numStmts, count int
+	fieldsScanned, err := fmt.Sscanf(line[lastColon+1:], "%d.%d,%d.%d %d %d",
+		&startLine, &startCol, &endLine, &endCol, &numStmts, &count)
+	if err != nil || fieldsScanned != 6 {
 		return "", block{}, fmt.Errorf("malformed profile line %q", line)
 	}
-	return file, block{startLine: sl, endLine: el, numStmts: stmts, count: count}, nil
+	return file, block{
+		startLine: startLine,
+		endLine:   endLine,
+		numStmts:  numStmts,
+		count:     count,
+	}, nil
 }
 
-// parseDiff extracts the added-line numbers per new-side file path from a
-// unified diff. Only non-test .go files outside test/ are kept.
-func parseDiff(path string) (map[string][]int, error) {
-	data, err := os.ReadFile(path)
+// The diff is the unified-diff text written by git diff -U0. It is a sequence
+// of per-file sections, each a few header lines followed by hunks:
+//
+//	diff --git a/pkg/config/config.go b/pkg/config/config.go
+//	index 1a2b3c4..5d6e7f8 100644
+//	--- a/pkg/config/config.go
+//	+++ b/pkg/config/config.go
+//	@@ -58,0 +59,3 @@ func Load() (*Config, error) {
+//	+	if err := validate(cfg); err != nil {
+//	+		return nil, err
+//	+	}
+//
+// Only two of those line kinds carry what patch coverage needs. The "+++ "
+// line names the file on the new side, normally prefixed with "b/" and
+// possibly followed by a tab and a timestamp; it reads "/dev/null" when the
+// file was deleted, in which case the section adds nothing. Hunk headers have
+// the shape
+//
+//	@@ -<oldStart>[,<oldCount>] +<newStart>[,<newCount>] @@ [section heading]
+//
+// where an omitted count means 1 and a count of 0 means the hunk touches
+// nothing on that side (a pure deletion has "+<newStart>,0").
+//
+// Because -U0 emits no context lines, every line inside a hunk is an added or
+// removed line, so the new-side range of the header *is* the set of added
+// line numbers — the parser reads the headers alone and never looks at hunk
+// bodies. That also means a section with no hunks at all, as produced by a
+// pure rename or mode change, contributes nothing. The flip side of matching
+// on line prefixes is that an added line whose own text starts with "+++ "
+// would be mistaken for a file header; Go sources do not produce such lines
+// in practice.
+//
+// parseDiff extracts the added-line numbers per new-side file path. Only
+// non-test .go files outside test/ are kept.
+func parseDiff(diffPath string) (map[string][]int, error) {
+	data, err := os.ReadFile(diffPath)
 	if err != nil {
 		return nil, err
 	}
-	return parseDiffBytes(data, path)
+	return parseDiffBytes(data, diffPath)
 }
 
 // parseDiffBytes is parseDiff over an in-memory diff; source only names the
 // input in error messages.
 func parseDiffBytes(data []byte, source string) (map[string][]int, error) {
 	added := map[string][]int{}
-	current := ""
+	currentFile := ""
 	for _, line := range strings.Split(string(data), "\n") {
 		switch {
 		case strings.HasPrefix(line, "+++ "):
-			current = ""
+			currentFile = ""
 			name := strings.TrimSpace(strings.TrimPrefix(line, "+++ "))
-			if i := strings.IndexByte(name, '\t'); i >= 0 {
-				name = name[:i]
+			if tabIndex := strings.IndexByte(name, '\t'); tabIndex >= 0 {
+				name = name[:tabIndex]
 			}
 			if name == "/dev/null" {
 				continue
 			}
 			name = strings.TrimPrefix(name, "b/")
 			if coverableFile(name) {
-				current = name
+				currentFile = name
 			}
-		case strings.HasPrefix(line, "@@ ") && current != "":
-			start, count, err := parseHunkHeader(line)
+		case strings.HasPrefix(line, "@@ ") && currentFile != "":
+			startLine, lineCount, err := parseHunkHeader(line)
 			if err != nil {
 				return nil, fmt.Errorf("%s: %v", source, err)
 			}
-			for i := 0; i < count; i++ {
-				added[current] = append(added[current], start+i)
+			for offset := 0; offset < lineCount; offset++ {
+				added[currentFile] = append(added[currentFile], startLine+offset)
 			}
 		}
 	}
@@ -214,26 +252,26 @@ func coverableFile(name string) bool {
 
 // parseHunkHeader returns the new-side start line and line count from a
 // "@@ -a,b +c,d @@" header ("+c" alone means one line, "+c,0" means none).
-func parseHunkHeader(line string) (start, count int, err error) {
+func parseHunkHeader(line string) (startLine, lineCount int, err error) {
 	fields := strings.Fields(line)
-	for _, f := range fields {
-		if !strings.HasPrefix(f, "+") {
+	for _, field := range fields {
+		if !strings.HasPrefix(field, "+") {
 			continue
 		}
-		spec := strings.TrimPrefix(f, "+")
-		count = 1
-		if i := strings.IndexByte(spec, ','); i >= 0 {
-			count, err = strconv.Atoi(spec[i+1:])
+		newSideSpec := strings.TrimPrefix(field, "+")
+		lineCount = 1
+		if commaIndex := strings.IndexByte(newSideSpec, ','); commaIndex >= 0 {
+			lineCount, err = strconv.Atoi(newSideSpec[commaIndex+1:])
 			if err != nil {
 				return 0, 0, fmt.Errorf("malformed hunk header %q", line)
 			}
-			spec = spec[:i]
+			newSideSpec = newSideSpec[:commaIndex]
 		}
-		start, err = strconv.Atoi(spec)
+		startLine, err = strconv.Atoi(newSideSpec)
 		if err != nil {
 			return 0, 0, fmt.Errorf("malformed hunk header %q", line)
 		}
-		return start, count, nil
+		return startLine, lineCount, nil
 	}
 	return 0, 0, fmt.Errorf("malformed hunk header %q", line)
 }
@@ -243,73 +281,74 @@ type tally struct {
 	total   int
 }
 
-func (t tally) percent() float64 {
-	if t.total == 0 {
+func (counts tally) percent() float64 {
+	if counts.total == 0 {
 		return 0
 	}
-	return 100 * float64(t.covered) / float64(t.total)
+	return 100 * float64(counts.covered) / float64(counts.total)
 }
 
-func (t *tally) add(b block) {
-	t.total += b.numStmts
-	if b.count > 0 {
-		t.covered += b.numStmts
+func (counts *tally) add(coverageBlock block) {
+	counts.total += coverageBlock.numStmts
+	if coverageBlock.count > 0 {
+		counts.covered += coverageBlock.numStmts
 	}
 }
 
 // perPackage aggregates a profile into per-package statement tallies.
-func perPackage(p profile) map[string]tally {
-	pkgs := map[string]tally{}
-	for file, blocks := range p {
-		pkg := path.Dir(file)
-		t := pkgs[pkg]
-		for _, b := range blocks {
-			t.add(b)
+func perPackage(coverage profile) map[string]tally {
+	packages := map[string]tally{}
+	for file, blocks := range coverage {
+		packageName := path.Dir(file)
+		packageTally := packages[packageName]
+		for _, coverageBlock := range blocks {
+			packageTally.add(coverageBlock)
 		}
-		pkgs[pkg] = t
+		packages[packageName] = packageTally
 	}
-	return pkgs
+	return packages
 }
 
-func totalTally(p profile) tally {
-	var t tally
-	for _, blocks := range p {
-		for _, b := range blocks {
-			t.add(b)
+func totalTally(coverage profile) tally {
+	var total tally
+	for _, blocks := range coverage {
+		for _, coverageBlock := range blocks {
+			total.add(coverageBlock)
 		}
 	}
-	return t
+	return total
 }
 
-// patchTally computes per-file patch coverage: statements of blocks that
-// overlap added lines, and how many of those statements ran.
+// fileStat is one file's patch coverage: statements of blocks that overlap
+// added lines, how many of those statements ran, and the added lines left
+// uncovered.
 type fileStat struct {
 	file      string
-	t         tally
+	coverage  tally
 	uncovered []int
 }
 
 func patchCoverage(head profile, added map[string][]int, module string) []fileStat {
 	var stats []fileStat
 	files := make([]string, 0, len(added))
-	for f := range added {
-		files = append(files, f)
+	for file := range added {
+		files = append(files, file)
 	}
 	sort.Strings(files)
 
 	for _, file := range files {
-		lines := added[file]
-		lineSet := map[int]bool{}
-		for _, l := range lines {
-			lineSet[l] = true
+		addedLines := added[file]
+		isAddedLine := map[int]bool{}
+		for _, line := range addedLines {
+			isAddedLine[line] = true
 		}
 		blocks := head[module+"/"+file]
-		var st fileStat
-		st.file = file
-		for _, b := range blocks {
+		var stat fileStat
+		stat.file = file
+		for _, coverageBlock := range blocks {
 			touched := false
-			for l := b.startLine; l <= b.endLine; l++ {
-				if lineSet[l] {
+			for line := coverageBlock.startLine; line <= coverageBlock.endLine; line++ {
+				if isAddedLine[line] {
 					touched = true
 					break
 				}
@@ -317,34 +356,34 @@ func patchCoverage(head profile, added map[string][]int, module string) []fileSt
 			if !touched {
 				continue
 			}
-			st.t.add(b)
-			if b.count == 0 {
-				for l := b.startLine; l <= b.endLine; l++ {
-					if lineSet[l] {
-						st.uncovered = append(st.uncovered, l)
+			stat.coverage.add(coverageBlock)
+			if coverageBlock.count == 0 {
+				for line := coverageBlock.startLine; line <= coverageBlock.endLine; line++ {
+					if isAddedLine[line] {
+						stat.uncovered = append(stat.uncovered, line)
 					}
 				}
 			}
 		}
-		if st.t.total > 0 {
-			sort.Ints(st.uncovered)
-			st.uncovered = dedupInts(st.uncovered)
-			stats = append(stats, st)
+		if stat.coverage.total > 0 {
+			sort.Ints(stat.uncovered)
+			stat.uncovered = dedupInts(stat.uncovered)
+			stats = append(stats, stat)
 		}
 	}
 	return stats
 }
 
-func dedupInts(s []int) []int {
-	out := s[:0]
-	prev := -1
-	for _, v := range s {
-		if v != prev {
-			out = append(out, v)
+func dedupInts(sorted []int) []int {
+	deduped := sorted[:0]
+	previous := -1
+	for _, value := range sorted {
+		if value != previous {
+			deduped = append(deduped, value)
 		}
-		prev = v
+		previous = value
 	}
-	return out
+	return deduped
 }
 
 // compressRanges renders sorted line numbers as "12-15, 22".
@@ -361,13 +400,13 @@ func compressRanges(lines []int) string {
 			parts = append(parts, fmt.Sprintf("%d-%d", start, end))
 		}
 	}
-	for _, l := range lines[1:] {
-		if l == end+1 {
-			end = l
+	for _, line := range lines[1:] {
+		if line == end+1 {
+			end = line
 			continue
 		}
 		flush()
-		start, end = l, l
+		start, end = line, line
 	}
 	flush()
 	return strings.Join(parts, ", ")
@@ -382,11 +421,11 @@ func shortPkg(pkg, module string) string {
 
 func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
 	module, commit, baseName string) string {
-	var b strings.Builder
-	b.WriteString("<!-- devgo-coverage-report -->\n")
-	b.WriteString("## Coverage report\n\n")
+	var report strings.Builder
+	report.WriteString("<!-- devgo-coverage-report -->\n")
+	report.WriteString("## Coverage report\n\n")
 	if commit != "" {
-		fmt.Fprintf(&b, "Commit: `%s`\n\n", commit)
+		fmt.Fprintf(&report, "Commit: `%s`\n\n", commit)
 	}
 
 	headTotal := totalTally(head)
@@ -402,9 +441,9 @@ func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
 	if haveDiff {
 		patchStats = patchCoverage(head, added, module)
 		var patchTotal tally
-		for _, st := range patchStats {
-			patchTotal.covered += st.t.covered
-			patchTotal.total += st.t.total
+		for _, stat := range patchStats {
+			patchTotal.covered += stat.coverage.covered
+			patchTotal.total += stat.coverage.total
 		}
 		if patchTotal.total == 0 {
 			patchLine = "**Patch:** n/a (no coverable changes)"
@@ -414,43 +453,43 @@ func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
 		}
 	}
 
-	b.WriteString(projectLine)
+	report.WriteString(projectLine)
 	if patchLine != "" {
-		b.WriteString(" &nbsp;&nbsp; " + patchLine)
+		report.WriteString(" &nbsp;&nbsp; " + patchLine)
 	}
-	b.WriteString("\n\n")
+	report.WriteString("\n\n")
 	if base == nil {
-		b.WriteString("_Baseline unavailable — project delta omitted._\n\n")
+		report.WriteString("_Baseline unavailable — project delta omitted._\n\n")
 	}
 
 	if base != nil {
-		writePackageDelta(&b, head, base, module, baseName)
+		writePackageDelta(&report, head, base, module, baseName)
 	}
 	if len(patchStats) > 0 {
-		writePatchTable(&b, patchStats)
+		writePatchTable(&report, patchStats)
 	}
 
-	b.WriteString("---\n")
-	b.WriteString("To browse the full HTML report locally, check out this branch and run " +
+	report.WriteString("---\n")
+	report.WriteString("To browse the full HTML report locally, check out this branch and run " +
 		"`make test-coverage`, then open `coverage.html`.\n")
-	return b.String()
+	return report.String()
 }
 
-func writePackageDelta(b *strings.Builder, head, base profile, module, baseName string) {
-	headPkgs := perPackage(head)
-	basePkgs := perPackage(base)
-	pkgSet := map[string]bool{}
-	for p := range headPkgs {
-		pkgSet[p] = true
+func writePackageDelta(report *strings.Builder, head, base profile, module, baseName string) {
+	headPackages := perPackage(head)
+	basePackages := perPackage(base)
+	seenPackages := map[string]bool{}
+	for packageName := range headPackages {
+		seenPackages[packageName] = true
 	}
-	for p := range basePkgs {
-		pkgSet[p] = true
+	for packageName := range basePackages {
+		seenPackages[packageName] = true
 	}
-	pkgs := make([]string, 0, len(pkgSet))
-	for p := range pkgSet {
-		pkgs = append(pkgs, p)
+	packages := make([]string, 0, len(seenPackages))
+	for packageName := range seenPackages {
+		packages = append(packages, packageName)
 	}
-	sort.Strings(pkgs)
+	sort.Strings(packages)
 
 	type row struct {
 		name     string
@@ -459,44 +498,46 @@ func writePackageDelta(b *strings.Builder, head, base profile, module, baseName 
 		deltaPct string
 	}
 	var rows []row
-	for _, p := range pkgs {
-		ht, inHead := headPkgs[p]
-		bt, inBase := basePkgs[p]
+	for _, packageName := range packages {
+		headTally, inHead := headPackages[packageName]
+		baseTally, inBase := basePackages[packageName]
 		switch {
 		case inHead && !inBase:
-			rows = append(rows, row{shortPkg(p, module),
-				fmt.Sprintf("%.1f%%", ht.percent()), "—", "new"})
+			rows = append(rows, row{shortPkg(packageName, module),
+				fmt.Sprintf("%.1f%%", headTally.percent()), "—", "new"})
 		case !inHead && inBase:
-			rows = append(rows, row{shortPkg(p, module),
-				"—", fmt.Sprintf("%.1f%%", bt.percent()), "removed"})
-		case ht.percent() != bt.percent():
-			rows = append(rows, row{shortPkg(p, module),
-				fmt.Sprintf("%.1f%%", ht.percent()),
-				fmt.Sprintf("%.1f%%", bt.percent()),
-				fmt.Sprintf("%+.1f%%", ht.percent()-bt.percent())})
+			rows = append(rows, row{shortPkg(packageName, module),
+				"—", fmt.Sprintf("%.1f%%", baseTally.percent()), "removed"})
+		case headTally.percent() != baseTally.percent():
+			rows = append(rows, row{shortPkg(packageName, module),
+				fmt.Sprintf("%.1f%%", headTally.percent()),
+				fmt.Sprintf("%.1f%%", baseTally.percent()),
+				fmt.Sprintf("%+.1f%%", headTally.percent()-baseTally.percent())})
 		}
 	}
 	if len(rows) == 0 {
-		b.WriteString("_No per-package coverage changes._\n\n")
+		report.WriteString("_No per-package coverage changes._\n\n")
 		return
 	}
 
-	b.WriteString("<details>\n<summary>Per-package coverage changes</summary>\n\n")
-	fmt.Fprintf(b, "| Package | HEAD | %s | Δ |\n", baseName)
-	b.WriteString("| --- | ---: | ---: | ---: |\n")
-	for _, r := range rows {
-		fmt.Fprintf(b, "| %s | %s | %s | %s |\n", r.name, r.headPct, r.basePct, r.deltaPct)
+	report.WriteString("<details>\n<summary>Per-package coverage changes</summary>\n\n")
+	fmt.Fprintf(report, "| Package | HEAD | %s | Δ |\n", baseName)
+	report.WriteString("| --- | ---: | ---: | ---: |\n")
+	for _, packageRow := range rows {
+		fmt.Fprintf(report, "| %s | %s | %s | %s |\n",
+			packageRow.name, packageRow.headPct, packageRow.basePct, packageRow.deltaPct)
 	}
-	b.WriteString("\n</details>\n\n")
+	report.WriteString("\n</details>\n\n")
 }
 
-func writePatchTable(b *strings.Builder, stats []fileStat) {
-	b.WriteString("<details>\n<summary>Patch coverage by file</summary>\n\n")
-	b.WriteString("| File | Coverage | Statements | Uncovered new lines |\n")
-	b.WriteString("| --- | ---: | ---: | --- |\n")
-	for _, st := range stats {
-		fmt.Fprintf(b, "| %s | %.1f%% | %d/%d | %s |\n",
-			st.file, st.t.percent(), st.t.covered, st.t.total, compressRanges(st.uncovered))
+func writePatchTable(report *strings.Builder, stats []fileStat) {
+	report.WriteString("<details>\n<summary>Patch coverage by file</summary>\n\n")
+	report.WriteString("| File | Coverage | Statements | Uncovered new lines |\n")
+	report.WriteString("| --- | ---: | ---: | --- |\n")
+	for _, stat := range stats {
+		fmt.Fprintf(report, "| %s | %.1f%% | %d/%d | %s |\n",
+			stat.file, stat.coverage.percent(), stat.coverage.covered, stat.coverage.total,
+			compressRanges(stat.uncovered))
 	}
-	b.WriteString("\n</details>\n\n")
+	report.WriteString("\n</details>\n\n")
 }


### PR DESCRIPTION
**Stack 1/5** — base: `main`. Followed by #85 (baseline storage) → #86 (HTML browser) → #87 (diff view) → #83 (syntax highlighting).

## Summary

Removes the Codecov dependency and computes coverage entirely inside GitHub Actions.

- **`tools/covreport`** — new stdlib-only Go tool that parses `go test -coverprofile` output and a `git diff -U0`, and prints a markdown report: project coverage with a delta against the base profile (per-package breakdown), and patch coverage over added lines (per-file breakdown with uncovered line ranges). Both input formats are documented in full next to the code that parses them.
- **New `coverage` job** in `test.yml` (pull requests only):
  - Runs the coverage tests on the head commit and regenerates the base profile from the merge-base in a worktree. (#85 replaces this with a stored baseline so the base is never re-tested.)
  - Writes the report to the job summary and maintains a **single sticky PR comment** (identified by a hidden marker) that is updated in place on new pushes and force-pushes; per-PR `concurrency` with `cancel-in-progress` prevents a stale run from overwriting a newer result.
  - Informational only — never fails on coverage percentages (matches the old `fail_ci_if_error: false` behavior).
  - Fork PRs skip the comment step (no write token) but still get the job summary.
- **`test` matrix** keeps `go test -race` as a pure correctness gate and no longer produces coverage profiles; the codecov-action upload step is deleted.
- **`pull_request` trigger no longer filters on base `main`.** It was `branches: [ main ]`, which silently skips every check on a pull request whose base is another branch — so the stack above this one would have had no CI at all. The `push` trigger stays pinned to `main`, so `record-coverage` in #85 is unaffected.
- **Make target**: `make coverage-report` prints the same markdown summary CI posts.
- Docs: release skill no longer references the `codecov/patch` / `codecov/project` checks; CLAUDE.md and README describe the new flow.

## Manual follow-ups (repo settings)

- Delete the `CODECOV_TOKEN` repository secret (no longer used)
- Optionally uninstall the Codecov GitHub App
- If `codecov/*` were ever set as required status checks, remove them

## Test plan

- [x] `tools/covreport/covreport_test.go` covers the **coverage profile format**: a block line in `set`, `count` and `atomic` mode, the last-colon split a module path with a port depends on, and the malformed shapes that must be rejected; over a whole profile, the skipped `mode:` header and blank lines, a file whose blocks are not contiguous, the dropped `_test.go` and `tools/` sources, a parse error naming file and line, a missing profile, and that all three modes tally identically
- [x] …and the **diff format**: `parseDiffBytes` (added-line extraction, `/dev/null` and deletion-only hunks, `_test.go`/`test/`/`tools/` exclusions), malformed-hunk errors naming their source, `parseHunkHeader` across the four hunk-header shapes, `compressRanges`, and `patchCoverage` dropping files with no coverable statements
- [x] Verified `covreport` output against hand-computed fixtures (project %, delta, patch %, uncovered line ranges)
- [x] This PR&#39;s own `coverage` job posts a sticky comment and reports a project delta against the merge-base
- [x] Confirmed the trigger change fixes the stack: PRs targeting a non-`main` base went from 0 checks to the full suite
- [x] `make build`, `go vet ./...`, `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv