### PR TITLE
Store coverage baselines on a coverage-data branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,18 +88,29 @@ jobs:
     - name: Run tests with coverage (head)
       run: go test -coverprofile=coverage.out -covermode=atomic ./...
 
-    # The base profile is regenerated from the merge-base in a worktree on
-    # every run: slower than caching a baseline, but immune to artifact
-    # expiry and always comparable to the exact commit the PR diffs against.
-    - name: Run tests with coverage (base)
+    # The base profile comes from the coverage-data branch, where the
+    # record-coverage job stores one profile per main commit — no second
+    # test run. If the merge-base itself has no stored profile yet (e.g.
+    # its record run is still in flight), walk back along first-parent
+    # history to the nearest recorded commit.
+    - name: Fetch baseline coverage
       run: |
         BASE=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
         echo "BASE=$BASE" >> "$GITHUB_ENV"
-        git worktree add /tmp/base "$BASE"
-        cd /tmp/base
-        go mod download
-        go test -coverprofile="$GITHUB_WORKSPACE/base-coverage.out" -covermode=atomic ./... \
-          || echo "::warning::base tests failed; project delta will be omitted"
+        git fetch origin coverage-data || true
+        if git rev-parse --verify --quiet origin/coverage-data >/dev/null; then
+          for sha in $(git rev-list --first-parent -n 50 "$BASE"); do
+            if git cat-file -e "origin/coverage-data:profiles/${sha}.out" 2>/dev/null; then
+              git show "origin/coverage-data:profiles/${sha}.out" > base-coverage.out
+              echo "BASELINE_SHA=$sha" >> "$GITHUB_ENV"
+              echo "using baseline from $sha"
+              break
+            fi
+          done
+        fi
+        if [ ! -s base-coverage.out ]; then
+          echo "::warning::no stored baseline on coverage-data; project delta will be omitted"
+        fi
 
     - name: Generate coverage report
       run: |
@@ -107,9 +118,9 @@ jobs:
         HEAD_SHA="${{ github.event.pull_request.head.sha }}"
         ARGS="-cover coverage.out -diff pr.diff"
         ARGS="$ARGS -commit ${HEAD_SHA:0:7}"
-        ARGS="$ARGS -base-name ${{ github.base_ref }}"
         if [ -s base-coverage.out ]; then
           ARGS="$ARGS -base-cover base-coverage.out"
+          ARGS="$ARGS -base-name ${{ github.base_ref }}@${BASELINE_SHA:0:7}"
         fi
         go run ./tools/covreport $ARGS > coverage-report.md
         cat coverage-report.md >> "$GITHUB_STEP_SUMMARY"
@@ -135,6 +146,60 @@ jobs:
           } else {
             await github.rest.issues.createComment({owner, repo, issue_number, body});
           }
+
+  # Stores the coverage profile of every main commit on the coverage-data
+  # branch (profiles/<sha>.out) so PR coverage runs can diff against a
+  # recorded baseline instead of re-running the tests on the merge-base.
+  record-coverage:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    # Serializes pushes to coverage-data so concurrent main pushes can't
+    # race each other on the branch update.
+    concurrency:
+      group: coverage-data
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.24'
+
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-mod-
+
+    - name: Download dependencies
+      run: go mod download
+
+    - name: Run tests with coverage
+      run: go test -coverprofile=coverage.out -covermode=atomic ./...
+
+    - name: Record profile on coverage-data branch
+      run: |
+        cp coverage.out /tmp/recorded-coverage.out
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        if git fetch origin coverage-data; then
+          git checkout -B coverage-data origin/coverage-data
+        else
+          git checkout --orphan coverage-data
+          git rm -rf --quiet .
+        fi
+        mkdir -p profiles
+        cp /tmp/recorded-coverage.out "profiles/${GITHUB_SHA}.out"
+        git add profiles
+        git commit -m "Record coverage for ${GITHUB_SHA}"
+        git push origin coverage-data
 
   integration:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.out
 coverage.html
 coverage*.out
 coverage*.html
+base-coverage.out

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,8 +62,9 @@ make help
 - **Integration tests**: Test with actual Docker containers and sample devcontainer configs
 - **CI/CD**: GitHub Actions workflow tests on Go 1.21–1.24. A `coverage` job posts a
   sticky PR comment with project/patch coverage diffs (computed by `tools/covreport`,
-  no external service). For an HTML view, run `make test-coverage` locally and open
-  `coverage.html`.
+  no external service). Baselines are recorded per main commit on the `coverage-data`
+  branch by the `record-coverage` job, so PR runs test only the head. For an HTML
+  view, run `make test-coverage` locally and open `coverage.html`.
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -579,9 +579,26 @@ anything under `test/` or `tools/`.
 #### How CI reports it
 
 On every pull request the `coverage` job runs the coverage tests on the head
-commit and on the merge-base, writes the report to the job summary, and
-maintains a **single sticky comment** on the PR that is updated in place on
-each push. The job is informational — it never fails on a coverage
-percentage. Pull requests from forks get the job summary but no comment,
-since they have no write token.
+commit, writes the report to the job summary, and maintains a **single sticky
+comment** on the PR that is updated in place on each push. The job is
+informational — it never fails on a coverage percentage. Pull requests from
+forks get the job summary but no comment, since they have no write token.
+
+#### The `coverage-data` branch
+
+Baselines live on a dedicated orphan branch named **`coverage-data`**, which
+holds nothing but coverage profiles at `profiles/<commit-sha>.out`. It carries
+no project source and is never merged into `main`.
+
+- On every push to `main`, the `record-coverage` job runs the coverage tests
+  once and commits that commit's profile to `coverage-data`. Concurrent pushes
+  are serialized so they cannot clobber each other, and the branch is created
+  as an orphan on the first run.
+- Pull request runs *read* that branch to get their baseline, so they only
+  ever test their own head — the base branch is never re-tested. If the
+  merge-base has no stored profile yet (for example its record run is still in
+  flight), the job walks back along first-parent history up to 50 commits to
+  find the nearest recorded one, and the report labels which commit it used.
+- If no baseline is found at all, the report says "Baseline unavailable" and
+  omits the project delta; patch coverage is unaffected.
 


### PR DESCRIPTION
**Stack 2/5** — base: #84. Review only the top commit; the rest belongs to the PR below.

## Summary

Replaces "re-run the base branch's tests on every PR" with a stored baseline, the way Codecov tracked main.

- **New `record-coverage` job** (pushes to main only) — runs the coverage tests once per main commit and records the profile as `profiles/<sha>.out` on a dedicated **`coverage-data`** orphan branch. The branch holds nothing but profiles, carries no project source, and is never merged into `main`. It is created as an orphan on the first run, and updates are serialized via a concurrency group so concurrent main pushes cannot clobber each other.
- **`coverage` job** now *reads* that branch instead of re-testing the base: a PR run only ever tests its own head. When the merge-base has no stored profile yet (for example its record run is still in flight), the job walks back along first-parent history up to 50 commits to the nearest recorded one, and the report labels which commit it used (`main@<sha>`).
- When no baseline is found at all the report says "Baseline unavailable" and omits the project delta; patch coverage is unaffected.

This roughly halves the `coverage` job's wall-clock on PRs, since the base profile is fetched rather than computed.

Note: until the first push to main after this merges, PRs will show "Baseline unavailable" — the `coverage-data` branch is populated by the `record-coverage` job.

## Test plan

- [x] Ran the full flow locally in a scratch clone: orphan creation on first record, a second record appending to the branch, and the first-parent walk-back when the merge-base profile is absent
- [x] `.gitignore` covers the profile artifacts the jobs write
- [x] `make build`, `go vet ./...`, `golangci-lint run` clean; `tools/covreport` tests pass unchanged (this PR touches only CI and docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv)_