### PR TITLE
Add readable HTML coverage browser to covreport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ install:
 # Run tests with coverage
 test-coverage:
 	go test -v -coverprofile=coverage.out ./...
-	go tool cover -html=coverage.out -o coverage.html
+	go run ./tools/covreport -cover coverage.out -format html > coverage.html
 
 # Print a markdown coverage summary (same tool CI uses for PR comments)
 coverage-report: test-coverage

--- a/README.md
+++ b/README.md
@@ -550,16 +550,20 @@ make ci
 ### Test Coverage
 
 Coverage is computed in-repo — there is no external coverage service.
-`tools/covreport` reads a `go test -coverprofile` profile and renders it as a
-markdown summary.
+`tools/covreport` reads a `go test -coverprofile` profile and renders it as
+either a markdown summary or a self-contained HTML report.
 
 ```bash
-# Run tests and write coverage.out plus an HTML report
+# Run tests and write an HTML coverage browser to coverage.html
 make test-coverage
 
 # Print the same markdown summary CI posts on pull requests
 make coverage-report
 ```
+
+The HTML report has a per-file sidebar and marks covered and uncovered lines
+with tinted backgrounds, replacing the hard-to-read default theme of
+`go tool cover -html`.
 
 #### What the numbers mean
 

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -125,34 +125,34 @@ func TestPatchCoverageDropsEmptyFiles(t *testing.T) {
 
 // source20 builds a 20-line file so line numbers match their content.
 func source20() string {
-	var b strings.Builder
-	for i := 1; i <= 20; i++ {
-		fmt.Fprintf(&b, "line %d\n", i)
+	var source strings.Builder
+	for lineNumber := 1; lineNumber <= 20; lineNumber++ {
+		fmt.Fprintf(&source, "line %d\n", lineNumber)
 	}
 	// Trailing newline yields a final empty element, as os.ReadFile would.
-	return strings.TrimSuffix(b.String(), "\n")
+	return strings.TrimSuffix(source.String(), "\n")
 }
 
 func TestAnnotateFile(t *testing.T) {
 	blocks := []block{{startLine: 5, endLine: 6, numStmts: 2, count: 1}}
-	f := annotateFile("cmd/x.go", source20(), blocks)
+	file := annotateFile("cmd/x.go", source20(), blocks)
 
-	if len(f.Lines) != 20 {
-		t.Fatalf("got %d rows, want 20", len(f.Lines))
+	if len(file.Lines) != 20 {
+		t.Fatalf("got %d rows, want 20", len(file.Lines))
 	}
-	for i, l := range f.Lines {
-		if l.Num != i+1 {
-			t.Fatalf("row %d has line number %d", i, l.Num)
+	for index, row := range file.Lines {
+		if row.Num != index+1 {
+			t.Fatalf("row %d has line number %d", index, row.Num)
 		}
 	}
-	if f.Lines[4].Class != "cov" || f.Lines[5].Class != "cov" {
-		t.Errorf("lines 5-6 should be covered: %+v", f.Lines[4:6])
+	if file.Lines[4].Class != "cov" || file.Lines[5].Class != "cov" {
+		t.Errorf("lines 5-6 should be covered: %+v", file.Lines[4:6])
 	}
-	if f.Lines[6].Class != "" {
-		t.Errorf("line 7 is outside every block, got class %q", f.Lines[6].Class)
+	if file.Lines[6].Class != "" {
+		t.Errorf("line 7 is outside every block, got class %q", file.Lines[6].Class)
 	}
-	if f.ID != "cmd-x-go" {
-		t.Errorf("ID = %q, want cmd-x-go", f.ID)
+	if file.ID != "cmd-x-go" {
+		t.Errorf("ID = %q, want cmd-x-go", file.ID)
 	}
 }
 
@@ -163,8 +163,8 @@ func TestAnnotateFileUncoveredWins(t *testing.T) {
 		{startLine: 5, endLine: 7, numStmts: 3, count: 4},
 		{startLine: 6, endLine: 6, numStmts: 1, count: 0},
 	}
-	f := annotateFile("cmd/x.go", source20(), blocks)
-	if got := f.Lines[5].Class; got != "uncov" {
+	file := annotateFile("cmd/x.go", source20(), blocks)
+	if got := file.Lines[5].Class; got != "uncov" {
 		t.Errorf("line 6 class = %q, want uncov", got)
 	}
 }
@@ -174,13 +174,13 @@ func TestRenderHTML(t *testing.T) {
 	head := profile{
 		module + "/cmd/a.go": {{startLine: 5, endLine: 6, numStmts: 2, count: 1}},
 	}
-	source := func(rel string) ([]byte, error) { return []byte(source20()), nil }
+	readSource := func(relPath string) ([]byte, error) { return []byte(source20()), nil }
 
-	var buf bytes.Buffer
-	if err := renderHTML(&buf, head, module, "abc1234", source); err != nil {
+	var rendered bytes.Buffer
+	if err := renderHTML(&rendered, head, module, "abc1234", readSource); err != nil {
 		t.Fatalf("renderHTML returned error: %v", err)
 	}
-	out := buf.String()
+	page := rendered.String()
 
 	for _, want := range []string{
 		`<title>example.com/m coverage</title>`,
@@ -188,7 +188,7 @@ func TestRenderHTML(t *testing.T) {
 		`href="#cmd-a-go"`,
 		`<span class="cov">`,
 	} {
-		if !strings.Contains(out, want) {
+		if !strings.Contains(page, want) {
 			t.Errorf("report should contain %q", want)
 		}
 	}

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -116,5 +118,76 @@ func TestPatchCoverageDropsEmptyFiles(t *testing.T) {
 	stats := patchCoverage(head, added, module)
 	if len(stats) != 1 || stats[0].file != "cmd/a.go" {
 		t.Fatalf("patchCoverage = %+v, want only cmd/a.go", stats)
+	}
+}
+
+// source20 builds a 20-line file so line numbers match their content.
+func source20() string {
+	var b strings.Builder
+	for i := 1; i <= 20; i++ {
+		fmt.Fprintf(&b, "line %d\n", i)
+	}
+	// Trailing newline yields a final empty element, as os.ReadFile would.
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func TestAnnotateFile(t *testing.T) {
+	blocks := []block{{startLine: 5, endLine: 6, numStmts: 2, count: 1}}
+	f := annotateFile("cmd/x.go", source20(), blocks)
+
+	if len(f.Lines) != 20 {
+		t.Fatalf("got %d rows, want 20", len(f.Lines))
+	}
+	for i, l := range f.Lines {
+		if l.Num != i+1 {
+			t.Fatalf("row %d has line number %d", i, l.Num)
+		}
+	}
+	if f.Lines[4].Class != "cov" || f.Lines[5].Class != "cov" {
+		t.Errorf("lines 5-6 should be covered: %+v", f.Lines[4:6])
+	}
+	if f.Lines[6].Class != "" {
+		t.Errorf("line 7 is outside every block, got class %q", f.Lines[6].Class)
+	}
+	if f.ID != "cmd-x-go" {
+		t.Errorf("ID = %q, want cmd-x-go", f.ID)
+	}
+}
+
+// Uncovered has to win over covered when a line is inside blocks of both
+// kinds, so red always flags a line that still needs a test.
+func TestAnnotateFileUncoveredWins(t *testing.T) {
+	blocks := []block{
+		{startLine: 5, endLine: 7, numStmts: 3, count: 4},
+		{startLine: 6, endLine: 6, numStmts: 1, count: 0},
+	}
+	f := annotateFile("cmd/x.go", source20(), blocks)
+	if got := f.Lines[5].Class; got != "uncov" {
+		t.Errorf("line 6 class = %q, want uncov", got)
+	}
+}
+
+func TestRenderHTML(t *testing.T) {
+	const module = "example.com/m"
+	head := profile{
+		module + "/cmd/a.go": {{startLine: 5, endLine: 6, numStmts: 2, count: 1}},
+	}
+	source := func(rel string) ([]byte, error) { return []byte(source20()), nil }
+
+	var buf bytes.Buffer
+	if err := renderHTML(&buf, head, module, "abc1234", source); err != nil {
+		t.Fatalf("renderHTML returned error: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		`<title>example.com/m coverage</title>`,
+		`commit abc1234`,
+		`href="#cmd-a-go"`,
+		`<span class="cov">`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report should contain %q", want)
+		}
 	}
 }

--- a/tools/covreport/html.go
+++ b/tools/covreport/html.go
@@ -1,0 +1,216 @@
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"os"
+	"sort"
+	"strings"
+)
+
+// sourceReader returns the contents of a repository-relative source file.
+type sourceReader func(rel string) ([]byte, error)
+
+// renderHTML writes a self-contained, readable coverage browser: a sidebar
+// listing every file with its coverage percentage and a main pane showing
+// the annotated source. It replaces the hard-to-read default theme of
+// `go tool cover -html` and reads sources relative to the working
+// directory, so it must run from the repository root.
+func renderHTML(w io.Writer, p profile, module, commit string, source sourceReader) error {
+	if source == nil {
+		source = func(rel string) ([]byte, error) { return os.ReadFile(rel) }
+	}
+
+	var files []htmlFile
+	paths := make([]string, 0, len(p))
+	for f := range p {
+		paths = append(paths, f)
+	}
+	sort.Strings(paths)
+
+	for _, profPath := range paths {
+		rel := strings.TrimPrefix(profPath, module+"/")
+		src, err := source(rel)
+		if err != nil {
+			// Sources can be missing when the profile came from another
+			// commit; skip the file rather than failing the whole report.
+			fmt.Fprintf(os.Stderr, "covreport: skipping %s: %v\n", rel, err)
+			continue
+		}
+		files = append(files, annotateFile(rel, string(src), p[profPath]))
+	}
+
+	total := totalTally(p)
+	data := htmlData{
+		Module:  module,
+		Commit:  commit,
+		Percent: total.percent(),
+		Files:   files,
+	}
+	return htmlTemplate.Execute(w, data)
+}
+
+type htmlData struct {
+	Module  string
+	Commit  string
+	Percent float64
+	Files   []htmlFile
+}
+
+type htmlFile struct {
+	Path    string
+	ID      string
+	Percent float64
+	Lines   []htmlLine
+}
+
+type htmlLine struct {
+	Num   int
+	Class string // "", "cov", or "uncov"
+	Text  string
+}
+
+// annotateFile classifies each source line: uncovered wins over covered
+// when a line spans blocks of both kinds, so red always flags lines that
+// still need a test.
+func annotateFile(rel, src string, blocks []block) htmlFile {
+	srcLines := strings.Split(src, "\n")
+	classes := make([]string, len(srcLines)+1)
+	var t tally
+	for _, b := range blocks {
+		t.add(b)
+		class := "cov"
+		if b.count == 0 {
+			class = "uncov"
+		}
+		for l := b.startLine; l <= b.endLine && l < len(classes); l++ {
+			if classes[l] != "uncov" {
+				classes[l] = class
+			}
+		}
+	}
+
+	f := htmlFile{
+		Path:    rel,
+		ID:      strings.NewReplacer("/", "-", ".", "-").Replace(rel),
+		Percent: t.percent(),
+	}
+	for i, text := range srcLines {
+		f.Lines = append(f.Lines, htmlLine{Num: i + 1, Class: classes[i+1], Text: text})
+	}
+	return f
+}
+
+var htmlTemplate = template.Must(template.New("report").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{.Module}} coverage</title>
+<style>
+:root {
+  --bg: #ffffff; --fg: #1f2328; --muted: #656d76;
+  --panel: #f6f8fa; --border: #d0d7de; --accent: #0969da;
+  --cov-bg: #e6f4ea; --cov-edge: #1a7f37;
+  --uncov-bg: #ffebe9; --uncov-edge: #cf222e;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0d1117; --fg: #e6edf3; --muted: #8d96a0;
+    --panel: #161b22; --border: #30363d; --accent: #4493f8;
+    --cov-bg: #12261e; --cov-edge: #2ea043;
+    --uncov-bg: #2d1517; --uncov-edge: #f85149;
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--bg); color: var(--fg);
+  font: 14px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif;
+  display: flex; flex-direction: column; height: 100vh;
+}
+header {
+  padding: 10px 16px; border-bottom: 1px solid var(--border);
+  background: var(--panel); display: flex; gap: 16px; align-items: baseline;
+  flex-wrap: wrap;
+}
+header h1 { font-size: 15px; margin: 0; }
+header .total { color: var(--accent); font-weight: 600; }
+header .meta { color: var(--muted); font-size: 12px; }
+.legend { margin-left: auto; font-size: 12px; color: var(--muted); }
+.legend .cov, .legend .uncov { padding: 1px 8px; border-radius: 3px; }
+.legend .cov { background: var(--cov-bg); }
+.legend .uncov { background: var(--uncov-bg); }
+main { display: flex; flex: 1; min-height: 0; }
+nav {
+  width: 320px; overflow-y: auto; border-right: 1px solid var(--border);
+  background: var(--panel); padding: 8px 0; flex-shrink: 0;
+}
+nav a {
+  display: flex; justify-content: space-between; gap: 8px;
+  padding: 4px 16px; color: var(--fg); text-decoration: none;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px; white-space: nowrap;
+}
+nav a:hover { background: var(--border); }
+nav a.active { background: var(--accent); color: #fff; }
+nav a.active .pct { color: #fff; }
+nav .pct { color: var(--muted); }
+section { display: none; overflow: auto; flex: 1; padding: 12px 0; }
+section.active { display: block; }
+section h2 {
+  font-size: 13px; margin: 0 16px 8px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+pre {
+  margin: 0; font: 12px/1.45 ui-monospace, SFMono-Regular, Menlo,
+  Consolas, monospace; min-width: max-content; tab-size: 4;
+}
+pre span { display: block; padding: 0 16px 0 0; }
+pre .n {
+  display: inline-block; width: 4.5em; text-align: right;
+  padding-right: 12px; color: var(--muted); user-select: none;
+}
+/* Tabs are measured from the start of the line box, so the code must live
+   in its own inline-block for indentation to survive the number prefix. */
+pre .t { display: inline-block; white-space: pre; vertical-align: top; }
+pre .cov { background: var(--cov-bg); box-shadow: inset 3px 0 var(--cov-edge); }
+pre .uncov { background: var(--uncov-bg); box-shadow: inset 3px 0 var(--uncov-edge); }
+</style>
+</head>
+<body>
+<header>
+  <h1>{{.Module}}</h1>
+  <span class="total">{{printf "%.1f" .Percent}}%</span>
+  {{if .Commit}}<span class="meta">commit {{.Commit}}</span>{{end}}
+  <span class="legend">
+    <span class="cov">covered</span> <span class="uncov">not covered</span>
+    plain: not tracked
+  </span>
+</header>
+<main>
+<nav>
+{{range .Files}}<a href="#{{.ID}}" data-target="{{.ID}}">
+  <span>{{.Path}}</span><span class="pct">{{printf "%.1f" .Percent}}%</span>
+</a>
+{{end}}</nav>
+{{range .Files}}<section id="{{.ID}}">
+<h2>{{.Path}} — {{printf "%.1f" .Percent}}%</h2>
+<pre>{{range .Lines}}<span{{if .Class}} class="{{.Class}}"{{end}}><span class="n">{{.Num}}</span><span class="t">{{.Text}}</span></span>{{end}}</pre>
+</section>
+{{end}}</main>
+<script>
+const links = document.querySelectorAll('nav a');
+const show = id => {
+  document.querySelectorAll('section').forEach(s =>
+    s.classList.toggle('active', s.id === id));
+  links.forEach(a =>
+    a.classList.toggle('active', a.dataset.target === id));
+};
+links.forEach(a => a.addEventListener('click', () => show(a.dataset.target)));
+const initial = location.hash.slice(1);
+show(document.getElementById(initial) ? initial : (links[0] && links[0].dataset.target));
+</script>
+</body>
+</html>
+`))

--- a/tools/covreport/html.go
+++ b/tools/covreport/html.go
@@ -17,38 +17,39 @@ type sourceReader func(rel string) ([]byte, error)
 // the annotated source. It replaces the hard-to-read default theme of
 // `go tool cover -html` and reads sources relative to the working
 // directory, so it must run from the repository root.
-func renderHTML(w io.Writer, p profile, module, commit string, source sourceReader) error {
-	if source == nil {
-		source = func(rel string) ([]byte, error) { return os.ReadFile(rel) }
+func renderHTML(out io.Writer, coverage profile, module, commit string,
+	readSource sourceReader) error {
+	if readSource == nil {
+		readSource = func(relPath string) ([]byte, error) { return os.ReadFile(relPath) }
 	}
 
 	var files []htmlFile
-	paths := make([]string, 0, len(p))
-	for f := range p {
-		paths = append(paths, f)
+	profileKeys := make([]string, 0, len(coverage))
+	for profileKey := range coverage {
+		profileKeys = append(profileKeys, profileKey)
 	}
-	sort.Strings(paths)
+	sort.Strings(profileKeys)
 
-	for _, profPath := range paths {
-		rel := strings.TrimPrefix(profPath, module+"/")
-		src, err := source(rel)
+	for _, profileKey := range profileKeys {
+		relPath := strings.TrimPrefix(profileKey, module+"/")
+		sourceText, err := readSource(relPath)
 		if err != nil {
 			// Sources can be missing when the profile came from another
 			// commit; skip the file rather than failing the whole report.
-			fmt.Fprintf(os.Stderr, "covreport: skipping %s: %v\n", rel, err)
+			fmt.Fprintf(os.Stderr, "covreport: skipping %s: %v\n", relPath, err)
 			continue
 		}
-		files = append(files, annotateFile(rel, string(src), p[profPath]))
+		files = append(files, annotateFile(relPath, string(sourceText), coverage[profileKey]))
 	}
 
-	total := totalTally(p)
+	total := totalTally(coverage)
 	data := htmlData{
 		Module:  module,
 		Commit:  commit,
 		Percent: total.percent(),
 		Files:   files,
 	}
-	return htmlTemplate.Execute(w, data)
+	return htmlTemplate.Execute(out, data)
 }
 
 type htmlData struct {
@@ -74,32 +75,34 @@ type htmlLine struct {
 // annotateFile classifies each source line: uncovered wins over covered
 // when a line spans blocks of both kinds, so red always flags lines that
 // still need a test.
-func annotateFile(rel, src string, blocks []block) htmlFile {
-	srcLines := strings.Split(src, "\n")
-	classes := make([]string, len(srcLines)+1)
-	var t tally
-	for _, b := range blocks {
-		t.add(b)
+func annotateFile(relPath, sourceText string, blocks []block) htmlFile {
+	sourceLines := strings.Split(sourceText, "\n")
+	classByLine := make([]string, len(sourceLines)+1)
+	var fileTally tally
+	for _, coverageBlock := range blocks {
+		fileTally.add(coverageBlock)
 		class := "cov"
-		if b.count == 0 {
+		if coverageBlock.count == 0 {
 			class = "uncov"
 		}
-		for l := b.startLine; l <= b.endLine && l < len(classes); l++ {
-			if classes[l] != "uncov" {
-				classes[l] = class
+		for line := coverageBlock.startLine; line <= coverageBlock.endLine &&
+			line < len(classByLine); line++ {
+			if classByLine[line] != "uncov" {
+				classByLine[line] = class
 			}
 		}
 	}
 
-	f := htmlFile{
-		Path:    rel,
-		ID:      strings.NewReplacer("/", "-", ".", "-").Replace(rel),
-		Percent: t.percent(),
+	file := htmlFile{
+		Path:    relPath,
+		ID:      strings.NewReplacer("/", "-", ".", "-").Replace(relPath),
+		Percent: fileTally.percent(),
 	}
-	for i, text := range srcLines {
-		f.Lines = append(f.Lines, htmlLine{Num: i + 1, Class: classes[i+1], Text: text})
+	for index, text := range sourceLines {
+		file.Lines = append(file.Lines,
+			htmlLine{Num: index + 1, Class: classByLine[index+1], Text: text})
 	}
-	return f
+	return file
 }
 
 var htmlTemplate = template.Must(template.New("report").Parse(`<!DOCTYPE html>
@@ -200,16 +203,18 @@ pre .uncov { background: var(--uncov-bg); box-shadow: inset 3px 0 var(--uncov-ed
 </section>
 {{end}}</main>
 <script>
-const links = document.querySelectorAll('nav a');
-const show = id => {
-  document.querySelectorAll('section').forEach(s =>
-    s.classList.toggle('active', s.id === id));
-  links.forEach(a =>
-    a.classList.toggle('active', a.dataset.target === id));
+const fileLinks = document.querySelectorAll('nav a');
+const showFile = fileId => {
+  document.querySelectorAll('section').forEach(section =>
+    section.classList.toggle('active', section.id === fileId));
+  fileLinks.forEach(link =>
+    link.classList.toggle('active', link.dataset.target === fileId));
 };
-links.forEach(a => a.addEventListener('click', () => show(a.dataset.target)));
-const initial = location.hash.slice(1);
-show(document.getElementById(initial) ? initial : (links[0] && links[0].dataset.target));
+fileLinks.forEach(link =>
+  link.addEventListener('click', () => showFile(link.dataset.target)));
+const initialFile = location.hash.slice(1);
+showFile(document.getElementById(initialFile) ? initialFile
+  : (fileLinks[0] && fileLinks[0].dataset.target));
 </script>
 </body>
 </html>

--- a/tools/covreport/html.go
+++ b/tools/covreport/html.go
@@ -42,7 +42,7 @@ func renderHTML(out io.Writer, coverage profile, module, commit string,
 		files = append(files, annotateFile(relPath, string(sourceText), coverage[profileKey]))
 	}
 
-	total := totalTally(coverage)
+	total := aggregateTotal(coverage)
 	data := htmlData{
 		Module:  module,
 		Commit:  commit,

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -36,6 +36,8 @@ func main() {
 	module := flag.String("module", "", "module path (default: read from go.mod)")
 	commit := flag.String("commit", "", "head commit SHA to show in the report")
 	baseName := flag.String("base-name", "main", "display name of the base branch")
+	format := flag.String("format", "markdown",
+		"output format: markdown (PR report) or html (annotated source browser)")
 	flag.Parse()
 
 	if *coverPath == "" {
@@ -55,6 +57,18 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
 		os.Exit(1)
+	}
+
+	if *format == "html" {
+		if err := renderHTML(os.Stdout, head, *module, *commit, nil); err != nil {
+			fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if *format != "markdown" {
+		fmt.Fprintf(os.Stderr, "covreport: unknown format %q\n", *format)
+		os.Exit(2)
 	}
 
 	var base profile


### PR DESCRIPTION
**Stack 3/5** — base: #85. Review only the top commit; the rest belongs to the PRs below.

## Summary

Adds `-format html` to `covreport`: a self-contained coverage browser that replaces the hard-to-read default theme of `go tool cover -html`.

- Per-file sidebar with each file's coverage percentage, and a main pane showing the annotated source with line numbers.
- Covered and uncovered lines are marked with tinted backgrounds and a coloured edge bar on a readable light palette, with a dark variant via `prefers-color-scheme`.
- Uncovered wins over covered when a line falls inside blocks of both kinds, so red always flags a line that still needs a test.
- The whole page — CSS and all — is one file with no external requests, so it opens straight from disk.
- `make test-coverage` now writes `coverage.html` through `covreport` instead of `go tool cover`.

`renderHTML` takes a `sourceReader` so the source of each file can be injected; production passes `nil` and gets `os.ReadFile`. That is what lets the renderer be tested without touching the filesystem.

## Test plan

- [x] `TestAnnotateFile` — line numbering, per-line coverage classes, and the derived anchor ID
- [x] `TestAnnotateFileUncoveredWins` — a line inside both a covered and an uncovered block renders as uncovered
- [x] `TestRenderHTML` — title, commit label, sidebar anchor and coverage markup, with the source injected
- [x] Rendered the real repo profile and checked the light and dark palettes in headless Chromium
- [x] `make build`, `go vet ./...`, `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv)_