### PR TITLE
Add a diff coverage view to the HTML report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@ make test-integration
 # Run tests with coverage
 make test-coverage
 
+# Coverage for just the lines changed since a revision
+make coverage-diff BASE=main
+
 # Run linter
 make lint
 
@@ -64,7 +67,9 @@ make help
   sticky PR comment with project/patch coverage diffs (computed by `tools/covreport`,
   no external service). Baselines are recorded per main commit on the `coverage-data`
   branch by the `record-coverage` job, so PR runs test only the head. For an HTML
-  view, run `make test-coverage` locally and open `coverage.html`.
+  view, run `make test-coverage` locally and open `coverage.html`;
+  `make coverage-diff BASE=<rev>` produces the same file with a diff view
+  (changed hunks plus context) that toggles back to the full listing.
 
 ## Code Style
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build test lint clean install test-coverage test-integration coverage-report dev ci ci-full help
+.PHONY: build test lint clean install test-coverage test-integration coverage-report coverage-diff dev ci ci-full help
 
 # Default target
 .DEFAULT_GOAL := build
+
+# Base revision for the diff coverage view: make coverage-diff BASE=origin/main
+BASE ?= main
 
 help:
 	@echo "Available targets:"
@@ -10,6 +13,7 @@ help:
 	@echo "  test-integration - Run integration tests"
 	@echo "  test-coverage    - Run tests with coverage report"
 	@echo "  coverage-report  - Print markdown coverage summary"
+	@echo "  coverage-diff    - HTML coverage for lines changed since BASE (default main)"
 	@echo "  lint             - Run linter"
 	@echo "  clean            - Clean build artifacts"
 	@echo "  install          - Install binary to GOPATH/bin"
@@ -45,6 +49,14 @@ test-coverage:
 # Print a markdown coverage summary (same tool CI uses for PR comments)
 coverage-report: test-coverage
 	go run ./tools/covreport -cover coverage.out
+
+# Browse coverage for just the lines changed since BASE. The report holds both
+# views; toggle "Changed only" / "All files" in the header. Deliberately not
+# dependent on test-coverage, which overwrites coverage.html with the full view.
+coverage-diff:
+	go test -coverprofile=coverage.out ./...
+	go run ./tools/covreport -cover coverage.out -format html \
+	  -diff-base $(BASE) > coverage.html
 
 # Run integration tests
 test-integration:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-.PHONY: build test lint clean install test-coverage test-integration coverage-report coverage-diff dev ci ci-full help
+.PHONY: build test lint clean install test-coverage test-integration \
+	coverage-report coverage-diff dev ci ci-full help
 
 # Default target
 .DEFAULT_GOAL := build
 
 # Base revision for the diff coverage view: make coverage-diff BASE=origin/main
 BASE ?= main
+
+# Lines of context shown around each changed line in that view
+CONTEXT ?= 3
 
 help:
 	@echo "Available targets:"
@@ -13,7 +17,8 @@ help:
 	@echo "  test-integration - Run integration tests"
 	@echo "  test-coverage    - Run tests with coverage report"
 	@echo "  coverage-report  - Print markdown coverage summary"
-	@echo "  coverage-diff    - HTML coverage for lines changed since BASE (default main)"
+	@echo "  coverage-diff    - HTML coverage for lines changed since BASE (default main),"
+	@echo "                     with CONTEXT lines around each change (default 3)"
 	@echo "  lint             - Run linter"
 	@echo "  clean            - Clean build artifacts"
 	@echo "  install          - Install binary to GOPATH/bin"
@@ -56,7 +61,7 @@ coverage-report: test-coverage
 coverage-diff:
 	go test -coverprofile=coverage.out ./...
 	go run ./tools/covreport -cover coverage.out -format html \
-	  -diff-base $(BASE) > coverage.html
+	  -diff-base $(BASE) -diff-context $(CONTEXT) > coverage.html
 
 # Run integration tests
 test-integration:

--- a/README.md
+++ b/README.md
@@ -569,8 +569,9 @@ with tinted backgrounds, replacing the hard-to-read default theme of
 `go tool cover -html`.
 
 `make coverage-diff` renders only the changed hunks plus three lines of
-context; the page holds both views, so the header toggle switches between
-"Changed only" and "All files" without regenerating anything.
+context on each side — `make coverage-diff CONTEXT=8` widens that. The page
+holds both views, so the header toggle switches between "Changed only" and
+"All files" without regenerating anything.
 
 #### What the numbers mean
 

--- a/README.md
+++ b/README.md
@@ -559,11 +559,18 @@ make test-coverage
 
 # Print the same markdown summary CI posts on pull requests
 make coverage-report
+
+# HTML report focused on the lines changed since a revision (default: main)
+make coverage-diff BASE=origin/main
 ```
 
 The HTML report has a per-file sidebar and marks covered and uncovered lines
 with tinted backgrounds, replacing the hard-to-read default theme of
 `go tool cover -html`.
+
+`make coverage-diff` renders only the changed hunks plus three lines of
+context; the page holds both views, so the header toggle switches between
+"Changed only" and "All files" without regenerating anything.
 
 #### What the numbers mean
 

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -556,3 +556,153 @@ func TestParseProfileMissingFile(t *testing.T) {
 		t.Fatal("expected an error for a profile that does not exist")
 	}
 }
+
+func TestRangeLabel(t *testing.T) {
+	tests := []struct {
+		name    string
+		options htmlOptions
+		want    string
+	}{
+		{"base against the working tree", htmlOptions{DiffBase: "main"}, "main … working tree"},
+		{"base against a revision", htmlOptions{DiffBase: "main", DiffHead: "HEAD"}, "main … HEAD"},
+		{"a pre-generated diff file", htmlOptions{DiffFile: "pr.diff"}, "pr.diff"},
+		{"no diff at all", htmlOptions{}, ""},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := rangeLabel(testCase.options); got != testCase.want {
+				t.Errorf("rangeLabel = %q, want %q", got, testCase.want)
+			}
+		})
+	}
+}
+
+// A file whose source cannot be read is dropped from the listing, but its
+// statements still belong in the header, which otherwise reports a percentage
+// the markdown report contradicts.
+func TestRenderHTMLHeaderCountsUnreadableSources(t *testing.T) {
+	const module = "example.com/m"
+	head := profile{
+		module + "/cmd/a.go": {{startLine: 1, endLine: 2, numStmts: 2, count: 1}},
+		module + "/cmd/b.go": {{startLine: 1, endLine: 2, numStmts: 4, count: 0}},
+	}
+	added := map[string][]int{"cmd/a.go": {1}, "cmd/b.go": {1}}
+	options := htmlOptions{
+		Module: module, Added: added, HaveDiff: true, DiffBase: "main", Context: 3,
+		Source: func(relPath string) ([]byte, error) {
+			if relPath == "cmd/b.go" {
+				return nil, fmt.Errorf("gone at this revision")
+			}
+			return []byte("x\ny\nz\n"), nil
+		},
+	}
+
+	var rendered bytes.Buffer
+	if err := renderHTML(&rendered, head, options); err != nil {
+		t.Fatalf("renderHTML returned error: %v", err)
+	}
+	page := rendered.String()
+
+	// The markdown report counts 2 of 6; the header must agree.
+	if want := "patch 33.3% (2/6 statements)"; !strings.Contains(page, want) {
+		t.Errorf("header should contain %q", want)
+	}
+	// Only the header carries the statement counts; cmd/a.go's own section
+	// legitimately reads "patch 100.0%", since it is fully covered.
+	if strings.Contains(page, "patch 100.0% (") {
+		t.Error("header counted only the files it could render")
+	}
+	if strings.Contains(page, "cmd/b.go") {
+		t.Error("an unreadable source should not be rendered as a section")
+	}
+}
+
+// renderHTML must not write through the added-line map it is handed.
+func TestRenderHTMLDoesNotMutateAddedLines(t *testing.T) {
+	const module = "example.com/m"
+	head := profile{
+		module + "/cmd/a.go": {{startLine: 1, endLine: 2, numStmts: 2, count: 1}},
+	}
+	added := map[string][]int{"cmd/a.go": {12, 5, 5}}
+	options := htmlOptions{
+		Module: module, Added: added, HaveDiff: true, DiffBase: "main", Context: 3,
+		Source: func(relPath string) ([]byte, error) { return []byte(source20()), nil },
+	}
+
+	var rendered bytes.Buffer
+	if err := renderHTML(&rendered, head, options); err != nil {
+		t.Fatalf("renderHTML returned error: %v", err)
+	}
+	if want := []int{12, 5, 5}; !reflect.DeepEqual(added["cmd/a.go"], want) {
+		t.Errorf("caller's slice = %v, want %v untouched", added["cmd/a.go"], want)
+	}
+}
+
+func TestLoadAddedLines(t *testing.T) {
+	diff := "+++ b/cmd/up.go\n@@ -10,0 +11,2 @@\n+a()\n+b()\n"
+	diffPath := filepath.Join(t.TempDir(), "pr.diff")
+	if err := os.WriteFile(diffPath, []byte(diff), 0o600); err != nil {
+		t.Fatalf("writing the diff: %v", err)
+	}
+
+	t.Run("from a diff file", func(t *testing.T) {
+		added, haveDiff, err := loadAddedLines(diffPath, "", "")
+		if err != nil {
+			t.Fatalf("loadAddedLines returned error: %v", err)
+		}
+		if !haveDiff {
+			t.Error("a diff was requested, so haveDiff must be true")
+		}
+		if want := []int{11, 12}; !reflect.DeepEqual(added["cmd/up.go"], want) {
+			t.Errorf("added = %v, want %v", added["cmd/up.go"], want)
+		}
+	})
+
+	t.Run("no diff requested", func(t *testing.T) {
+		added, haveDiff, err := loadAddedLines("", "", "")
+		if err != nil {
+			t.Fatalf("loadAddedLines returned error: %v", err)
+		}
+		if haveDiff {
+			t.Error("no diff was requested, so haveDiff must be false")
+		}
+		if added != nil {
+			t.Errorf("added = %v, want nil", added)
+		}
+	})
+
+	// The bool says a diff was *requested*, so it stays true when reading it
+	// failed — a caller that carries on past the error still knows a patch
+	// column was asked for.
+	t.Run("unreadable diff file", func(t *testing.T) {
+		_, haveDiff, err := loadAddedLines(filepath.Join(t.TempDir(), "absent.diff"), "", "")
+		if err == nil {
+			t.Fatal("expected an error for a diff file that does not exist")
+		}
+		if !haveDiff {
+			t.Error("haveDiff must report the request, not whether it succeeded")
+		}
+	})
+}
+
+func TestSourceFor(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hello.txt")
+	if err := os.WriteFile(path, []byte("hello\n"), 0o600); err != nil {
+		t.Fatalf("writing the file: %v", err)
+	}
+
+	// An empty revision reads the working tree; a named one goes through git,
+	// which TestGitShowReadsAFileAtARevision covers.
+	readSource := sourceFor("")
+	got, err := readSource(path)
+	if err != nil {
+		t.Fatalf("sourceFor(\"\") returned error: %v", err)
+	}
+	if string(got) != "hello\n" {
+		t.Errorf("contents = %q, want %q", got, "hello\n")
+	}
+	if _, err := readSource(filepath.Join(dir, "absent.txt")); err == nil {
+		t.Error("expected an error for a file that does not exist")
+	}
+}

--- a/tools/covreport/covreport_test.go
+++ b/tools/covreport/covreport_test.go
@@ -8,6 +8,35 @@ import (
 	"testing"
 )
 
+func TestDiffRegions(t *testing.T) {
+	tests := []struct {
+		name    string
+		added   []int
+		total   int
+		context int
+		want    []region
+	}{
+		{"no added lines", nil, 20, 3, nil},
+		{"empty file", []int{1}, 0, 3, nil},
+		{"clamps at start", []int{2}, 20, 3, []region{{1, 5}}},
+		{"clamps at end", []int{19}, 20, 3, []region{{16, 20}}},
+		{"windows merge when touching", []int{5, 12}, 20, 3, []region{{2, 15}}},
+		{"windows stay apart", []int{5, 20}, 30, 3, []region{{2, 8}, {17, 23}}},
+		{"line past eof ignored", []int{5, 99}, 20, 3, []region{{2, 8}}},
+		{"line before start ignored", []int{0, 5}, 20, 3, []region{{2, 8}}},
+		{"zero context", []int{5, 6, 10}, 20, 0, []region{{5, 6}, {10, 10}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := diffRegions(tt.added, tt.total, tt.context)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("diffRegions(%v, %d, %d) = %v, want %v",
+					tt.added, tt.total, tt.context, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseDiffBytes(t *testing.T) {
 	diff := `diff --git a/cmd/up.go b/cmd/up.go
 --- a/cmd/up.go
@@ -108,6 +137,141 @@ func TestCompressRanges(t *testing.T) {
 	}
 }
 
+// source20 builds a 20-line file so line numbers match their content.
+func source20() string {
+	var b strings.Builder
+	for i := 1; i <= 20; i++ {
+		fmt.Fprintf(&b, "line %d\n", i)
+	}
+	// Trailing newline yields a final empty element, as os.ReadFile would.
+	return strings.TrimSuffix(b.String(), "\n")
+}
+
+func TestAnnotateFileDiff(t *testing.T) {
+	blocks := []block{
+		{startLine: 5, endLine: 6, numStmts: 2, count: 1},
+		{startLine: 12, endLine: 12, numStmts: 1, count: 0},
+	}
+	f := annotateFile("cmd/x.go", source20(), blocks, []int{5, 12}, 3)
+
+	if !f.Changed {
+		t.Error("file with added lines should be Changed")
+	}
+
+	var gaps []int
+	added := map[int]bool{}
+	visible := map[int]bool{}
+	for _, l := range f.Lines {
+		if l.Gap > 0 {
+			gaps = append(gaps, l.Gap)
+			continue
+		}
+		if l.Added {
+			added[l.Num] = true
+		}
+		if l.Visible {
+			visible[l.Num] = true
+		}
+	}
+
+	// Windows are 2-8 and 9-15 with context 3, which touch and merge into
+	// 2-15, leaving line 1 and lines 16-20 hidden.
+	if want := []int{1, 5}; !reflect.DeepEqual(gaps, want) {
+		t.Errorf("gap rows = %v, want %v", gaps, want)
+	}
+	if want := map[int]bool{5: true, 12: true}; !reflect.DeepEqual(added, want) {
+		t.Errorf("added lines = %v, want %v", added, want)
+	}
+	for n := 2; n <= 15; n++ {
+		if !visible[n] {
+			t.Errorf("line %d should be visible", n)
+		}
+	}
+	for _, n := range []int{1, 16, 20} {
+		if visible[n] {
+			t.Errorf("line %d should be hidden", n)
+		}
+	}
+	// Hidden lines stay in the slice for the all-files view, so the separator
+	// sits between the hidden run and the first visible line.
+	if got := f.Lines[0]; got.Gap != 0 || got.Num != 1 || got.Visible {
+		t.Errorf("row 0 should be hidden line 1, got %+v", got)
+	}
+	if got := f.Lines[1]; got.Gap != 1 {
+		t.Errorf("row 1 should be the leading gap, got %+v", got)
+	}
+	if got := f.Lines[2]; got.Num != 2 || !got.Visible {
+		t.Errorf("row 2 should be visible line 2, got %+v", got)
+	}
+	if got := f.Lines[len(f.Lines)-1]; got.Gap != 5 {
+		t.Errorf("last row should be the trailing gap, got %+v", got)
+	}
+}
+
+func TestAnnotateFileNoDiff(t *testing.T) {
+	blocks := []block{{startLine: 5, endLine: 6, numStmts: 2, count: 1}}
+	f := annotateFile("cmd/x.go", source20(), blocks, nil, 3)
+
+	if f.Changed {
+		t.Error("file without added lines should not be Changed")
+	}
+	if len(f.Lines) != 20 {
+		t.Fatalf("got %d rows, want 20", len(f.Lines))
+	}
+	for _, l := range f.Lines {
+		if l.Gap > 0 {
+			t.Errorf("line %d: no gap rows expected without a diff", l.Num)
+		}
+		if !l.Visible {
+			t.Errorf("line %d should be visible in the all-files view", l.Num)
+		}
+		if l.Added {
+			t.Errorf("line %d should not be marked added", l.Num)
+		}
+	}
+	if f.Lines[4].Class != "cov" || f.Lines[6].Class != "" {
+		t.Errorf("coverage classes misapplied: %+v", f.Lines[:7])
+	}
+}
+
+func TestAnnotateFileUncoveredWins(t *testing.T) {
+	blocks := []block{
+		{startLine: 5, endLine: 7, numStmts: 3, count: 4},
+		{startLine: 6, endLine: 6, numStmts: 1, count: 0},
+	}
+	f := annotateFile("cmd/x.go", source20(), blocks, nil, 3)
+	if got := f.Lines[5].Class; got != "uncov" {
+		t.Errorf("line 6 class = %q, want uncov", got)
+	}
+}
+
+func TestPatchTallies(t *testing.T) {
+	const module = "example.com/m"
+	head := profile{
+		module + "/cmd/a.go": {
+			{startLine: 10, endLine: 12, numStmts: 2, count: 1},
+			{startLine: 20, endLine: 22, numStmts: 3, count: 0},
+			{startLine: 40, endLine: 42, numStmts: 5, count: 1},
+		},
+	}
+	added := map[string][]int{
+		"cmd/a.go": {11, 21},
+		"cmd/b.go": {3}, // changed but absent from the profile
+	}
+
+	got := patchTallies(head, added, module)
+
+	if want := (tally{covered: 2, total: 5}); got["cmd/a.go"] != want {
+		t.Errorf("cmd/a.go tally = %+v, want %+v", got["cmd/a.go"], want)
+	}
+	if _, ok := got["cmd/b.go"]; !ok {
+		t.Error("a changed file with no coverable statements must still be present")
+	}
+	if want := (tally{}); got["cmd/b.go"] != want {
+		t.Errorf("cmd/b.go tally = %+v, want zero", got["cmd/b.go"])
+	}
+}
+
 func TestPatchCoverageDropsEmptyFiles(t *testing.T) {
 	const module = "example.com/m"
 	head := profile{
@@ -121,73 +285,101 @@ func TestPatchCoverageDropsEmptyFiles(t *testing.T) {
 	}
 }
 
-// source20 builds a 20-line file so line numbers match their content.
-func source20() string {
-	var b strings.Builder
-	for i := 1; i <= 20; i++ {
-		fmt.Fprintf(&b, "line %d\n", i)
-	}
-	// Trailing newline yields a final empty element, as os.ReadFile would.
-	return strings.TrimSuffix(b.String(), "\n")
-}
-
-func TestAnnotateFile(t *testing.T) {
-	blocks := []block{{startLine: 5, endLine: 6, numStmts: 2, count: 1}}
-	f := annotateFile("cmd/x.go", source20(), blocks)
-
-	if len(f.Lines) != 20 {
-		t.Fatalf("got %d rows, want 20", len(f.Lines))
-	}
-	for i, l := range f.Lines {
-		if l.Num != i+1 {
-			t.Fatalf("row %d has line number %d", i, l.Num)
-		}
-	}
-	if f.Lines[4].Class != "cov" || f.Lines[5].Class != "cov" {
-		t.Errorf("lines 5-6 should be covered: %+v", f.Lines[4:6])
-	}
-	if f.Lines[6].Class != "" {
-		t.Errorf("line 7 is outside every block, got class %q", f.Lines[6].Class)
-	}
-	if f.ID != "cmd-x-go" {
-		t.Errorf("ID = %q, want cmd-x-go", f.ID)
-	}
-}
-
-// Uncovered has to win over covered when a line is inside blocks of both
-// kinds, so red always flags a line that still needs a test.
-func TestAnnotateFileUncoveredWins(t *testing.T) {
-	blocks := []block{
-		{startLine: 5, endLine: 7, numStmts: 3, count: 4},
-		{startLine: 6, endLine: 6, numStmts: 1, count: 0},
-	}
-	f := annotateFile("cmd/x.go", source20(), blocks)
-	if got := f.Lines[5].Class; got != "uncov" {
-		t.Errorf("line 6 class = %q, want uncov", got)
-	}
-}
-
-func TestRenderHTML(t *testing.T) {
+func TestRenderHTMLDiff(t *testing.T) {
 	const module = "example.com/m"
 	head := profile{
-		module + "/cmd/a.go": {{startLine: 5, endLine: 6, numStmts: 2, count: 1}},
+		module + "/cmd/a.go": {
+			{startLine: 5, endLine: 6, numStmts: 2, count: 1},
+			{startLine: 12, endLine: 12, numStmts: 1, count: 0},
+		},
+		module + "/cmd/untouched.go": {
+			{startLine: 1, endLine: 2, numStmts: 1, count: 1},
+		},
 	}
-	source := func(rel string) ([]byte, error) { return []byte(source20()), nil }
+	opts := htmlOptions{
+		Module:   module,
+		Added:    map[string][]int{"cmd/a.go": {5, 12}},
+		HaveDiff: true,
+		DiffBase: "main",
+		Context:  3,
+		Source:   func(rel string) ([]byte, error) { return []byte(source20()), nil },
+	}
 
 	var buf bytes.Buffer
-	if err := renderHTML(&buf, head, module, "abc1234", source); err != nil {
+	if err := renderHTML(&buf, head, opts); err != nil {
 		t.Fatalf("renderHTML returned error: %v", err)
 	}
 	out := buf.String()
 
 	for _, want := range []string{
-		`<title>example.com/m coverage</title>`,
-		`commit abc1234`,
-		`href="#cmd-a-go"`,
-		`<span class="cov">`,
+		`<body class="mode-diff">`,
+		`class="gap"`,
+		` add"`,
+		`data-mode="diff"`,
+		`main … working tree`,
+		`patch 66.7% (2/3 statements)`,
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("report should contain %q", want)
+			t.Errorf("output missing %q", want)
 		}
+	}
+	// The untouched file is still emitted, just filtered by CSS in diff mode.
+	if !strings.Contains(out, "cmd/untouched.go") {
+		t.Error("all-files view should still contain untouched files")
+	}
+}
+
+func TestRenderHTMLNoDiff(t *testing.T) {
+	const module = "example.com/m"
+	head := profile{
+		module + "/cmd/a.go": {{startLine: 5, endLine: 6, numStmts: 2, count: 1}},
+	}
+	opts := htmlOptions{
+		Module: module,
+		Source: func(rel string) ([]byte, error) { return []byte(source20()), nil },
+	}
+
+	var buf bytes.Buffer
+	if err := renderHTML(&buf, head, opts); err != nil {
+		t.Fatalf("renderHTML returned error: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, `<body class="mode-all">`) {
+		t.Error("a report without a diff should open in all-files mode")
+	}
+	if strings.Contains(out, "data-mode=") {
+		t.Error("the mode toggle should not render without a diff")
+	}
+	if strings.Contains(out, `class="gap"`) {
+		t.Error("no elision separators should render without a diff")
+	}
+}
+
+func TestRenderHTMLEmptyDiff(t *testing.T) {
+	const module = "example.com/m"
+	head := profile{
+		module + "/cmd/a.go": {{startLine: 5, endLine: 6, numStmts: 2, count: 1}},
+	}
+	opts := htmlOptions{
+		Module:   module,
+		Added:    map[string][]int{},
+		HaveDiff: true,
+		DiffBase: "main",
+		Context:  3,
+		Source:   func(rel string) ([]byte, error) { return []byte(source20()), nil },
+	}
+
+	var buf bytes.Buffer
+	if err := renderHTML(&buf, head, opts); err != nil {
+		t.Fatalf("renderHTML returned error: %v", err)
+	}
+	out := buf.String()
+
+	if !strings.Contains(out, `<body class="mode-all">`) {
+		t.Error("a diff with no coverable changes should open in all-files mode")
+	}
+	if !strings.Contains(out, "No coverable changes") {
+		t.Error("the empty state should be rendered")
 	}
 }

--- a/tools/covreport/git.go
+++ b/tools/covreport/git.go
@@ -1,3 +1,9 @@
+// The git helpers back the -diff-base/-diff-head flags, which let covreport
+// take its own diff instead of being handed one. CI already has a diff to pass
+// via -diff; this exists so `make coverage-diff BASE=<rev>` works from a
+// working tree with no extra plumbing. Every call shells out rather than
+// linking a git library, to keep the tool dependency-free per the repository's
+// standard-library-first policy.
 package main
 
 import (
@@ -37,6 +43,11 @@ func gitDiff(base, head string) ([]byte, error) {
 	if head != "" {
 		args = append(args, head)
 	}
+	// The trailing "--" is what tells git the names before it are revisions.
+	// Without it a base whose name is also a path — cmd, test, tools and docs
+	// are all plausible branch names here — fails as ambiguous, and a base
+	// beginning with "-" is parsed as an option.
+	args = append(args, "--")
 	return runGit(args...)
 }
 

--- a/tools/covreport/git.go
+++ b/tools/covreport/git.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// runGit runs git and returns its stdout, folding stderr into the error so a
+// bad revision or a non-repository working directory surfaces git's own
+// message rather than a bare exit status.
+func runGit(args ...string) ([]byte, error) {
+	cmd := exec.Command("git", args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("git %s: %s", strings.Join(args, " "), msg)
+	}
+	return out, nil
+}
+
+// gitDiff produces the unified diff parseDiffBytes expects. An empty head
+// diffs base against the working tree.
+//
+// The prefixes are set explicitly because a user with diff.noprefix=true would
+// otherwise get "+++ pkg/x.go", and stripping "b/" would silently yield a path
+// that never matches the coverage profile.
+func gitDiff(base, head string) ([]byte, error) {
+	args := []string{"diff", "-U0", "--no-color", "--no-ext-diff",
+		"--src-prefix=a/", "--dst-prefix=b/", base}
+	if head != "" {
+		args = append(args, head)
+	}
+	return runGit(args...)
+}
+
+// gitShow returns a file's contents at rev. path is repository-relative, so
+// covreport must run from the repository root, as renderHTML already requires.
+func gitShow(rev, path string) ([]byte, error) {
+	return runGit("show", rev+":"+path)
+}

--- a/tools/covreport/git_test.go
+++ b/tools/covreport/git_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// chdir switches to dir for the duration of the test. testing.T.Chdir would
+// do this, but it landed in Go 1.24 and CI still builds on 1.21.
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	previous, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("reading the working directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("entering %s: %v", dir, err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(previous); err != nil {
+			t.Fatalf("returning to %s: %v", previous, err)
+		}
+	})
+}
+
+// setupRepo builds a repository whose second commit changes a file, and
+// returns its path. When branchName is not empty a branch of that name is
+// created pointing at the first commit, which is what makes a name that is
+// both a revision and a path ambiguous to git.
+func setupRepo(t *testing.T, fileName, branchName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+	run("init", "-q", ".")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+
+	path := filepath.Join(dir, fileName)
+	if err := os.WriteFile(path, []byte("first\n"), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", fileName, err)
+	}
+	run("add", ".")
+	run("commit", "-qm", "first")
+	if branchName != "" {
+		run("branch", branchName)
+	}
+	if err := os.WriteFile(path, []byte("first\nsecond\n"), 0o600); err != nil {
+		t.Fatalf("rewriting %s: %v", fileName, err)
+	}
+	run("add", ".")
+	run("commit", "-qm", "second")
+	return dir
+}
+
+// A base whose name is also a path in the tree is ambiguous to git unless the
+// revisions are terminated with "--". Branch names like cmd, test and tools
+// all collide with directories in this repository.
+func TestGitDiffAcceptsRefMatchingAPath(t *testing.T) {
+	chdir(t, setupRepo(t, "release", "release"))
+
+	out, err := gitDiff("release", "")
+	if err != nil {
+		t.Fatalf("gitDiff on a name that is both a revision and a path: %v", err)
+	}
+	if !strings.Contains(string(out), "+++ b/release") {
+		t.Errorf("diff should name the changed file on the new side:\n%s", out)
+	}
+}
+
+func TestGitDiffWithExplicitHead(t *testing.T) {
+	chdir(t, setupRepo(t, "app.go", ""))
+
+	out, err := gitDiff("HEAD~1", "HEAD")
+	if err != nil {
+		t.Fatalf("gitDiff returned error: %v", err)
+	}
+	added, err := parseDiffBytes(out, "test")
+	if err != nil {
+		t.Fatalf("parseDiffBytes on gitDiff output: %v", err)
+	}
+	if want := []int{2}; len(added["app.go"]) != 1 || added["app.go"][0] != want[0] {
+		t.Errorf("added lines = %v, want %v", added["app.go"], want)
+	}
+}
+
+func TestGitDiffUnknownRevisionReportsGitsMessage(t *testing.T) {
+	chdir(t, setupRepo(t, "app.go", ""))
+
+	_, err := gitDiff("no-such-revision", "")
+	if err == nil {
+		t.Fatal("expected an error for an unknown revision")
+	}
+	// runGit exists to fold stderr into the error; a bare exit status would
+	// leave the caller with nothing to act on.
+	if !strings.Contains(err.Error(), "no-such-revision") {
+		t.Errorf("error %q should carry git's own message", err)
+	}
+	if strings.Contains(err.Error(), "exit status") {
+		t.Errorf("error %q is the bare exit status, not git's message", err)
+	}
+}
+
+func TestGitShowReadsAFileAtARevision(t *testing.T) {
+	chdir(t, setupRepo(t, "app.go", ""))
+
+	atHead, err := gitShow("HEAD", "app.go")
+	if err != nil {
+		t.Fatalf("gitShow returned error: %v", err)
+	}
+	if got := string(atHead); got != "first\nsecond\n" {
+		t.Errorf("HEAD contents = %q", got)
+	}
+
+	atParent, err := gitShow("HEAD~1", "app.go")
+	if err != nil {
+		t.Fatalf("gitShow on the parent commit: %v", err)
+	}
+	if got := string(atParent); got != "first\n" {
+		t.Errorf("HEAD~1 contents = %q", got)
+	}
+
+	if _, err := gitShow("HEAD", "absent.go"); err == nil {
+		t.Error("expected an error for a path absent at that revision")
+	}
+}

--- a/tools/covreport/html.go
+++ b/tools/covreport/html.go
@@ -12,71 +12,208 @@ import (
 // sourceReader returns the contents of a repository-relative source file.
 type sourceReader func(rel string) ([]byte, error)
 
-// renderHTML writes a self-contained, readable coverage browser: a sidebar
-// listing every file with its coverage percentage and a main pane showing
-// the annotated source. It replaces the hard-to-read default theme of
-// `go tool cover -html` and reads sources relative to the working
-// directory, so it must run from the repository root.
-func renderHTML(w io.Writer, p profile, module, commit string, source sourceReader) error {
-	if source == nil {
-		source = func(rel string) ([]byte, error) { return os.ReadFile(rel) }
+// htmlOptions configures renderHTML. When Added is non-empty the report gains
+// a diff view alongside the full listing, toggled client-side.
+type htmlOptions struct {
+	Module   string
+	Commit   string
+	Added    map[string][]int // repo-relative path -> added line numbers
+	HaveDiff bool
+	DiffBase string
+	DiffHead string
+	DiffFile string // set when the diff came from -diff instead of a revision
+	Context  int
+	Source   sourceReader
+}
+
+// renderHTML writes a self-contained coverage browser: a sidebar listing every
+// file with its coverage percentage and a main pane showing the annotated
+// source. It replaces the hard-to-read default theme of `go tool cover -html`.
+//
+// When a diff is supplied the page carries both views — the changed hunks with
+// surrounding context, and the complete listing — and switches between them by
+// toggling a class on <body>, so the source text is emitted only once.
+func renderHTML(w io.Writer, p profile, opts htmlOptions) error {
+	if opts.Source == nil {
+		opts.Source = func(rel string) ([]byte, error) { return os.ReadFile(rel) }
 	}
+
+	// Changed files that never appear in the profile still belong in the
+	// report, so the path set is the union of both sides.
+	paths := map[string]bool{}
+	for f := range p {
+		paths[f] = true
+	}
+	if opts.HaveDiff {
+		for f := range opts.Added {
+			paths[opts.Module+"/"+f] = true
+		}
+	}
+	sorted := make([]string, 0, len(paths))
+	for f := range paths {
+		sorted = append(sorted, f)
+	}
+	sort.Strings(sorted)
+
+	tallies := patchTallies(p, opts.Added, opts.Module)
 
 	var files []htmlFile
-	paths := make([]string, 0, len(p))
-	for f := range p {
-		paths = append(paths, f)
-	}
-	sort.Strings(paths)
-
-	for _, profPath := range paths {
-		rel := strings.TrimPrefix(profPath, module+"/")
-		src, err := source(rel)
+	changed := 0
+	for _, profPath := range sorted {
+		rel := strings.TrimPrefix(profPath, opts.Module+"/")
+		src, err := opts.Source(rel)
 		if err != nil {
 			// Sources can be missing when the profile came from another
 			// commit; skip the file rather than failing the whole report.
 			fmt.Fprintf(os.Stderr, "covreport: skipping %s: %v\n", rel, err)
 			continue
 		}
-		files = append(files, annotateFile(rel, string(src), p[profPath]))
+		added := opts.Added[rel]
+		sort.Ints(added)
+		added = dedupInts(added)
+
+		f := annotateFile(rel, string(src), p[profPath], added, opts.Context)
+		if f.Changed {
+			changed++
+			// Patch numbers come from the profile, not the annotated source,
+			// so the header always matches the markdown report.
+			t := tallies[rel]
+			f.PatchCovered, f.PatchTotal = t.covered, t.total
+			f.PatchPercent = t.percent()
+		}
+		f.PatchLabel = "n/a"
+		if f.PatchTotal > 0 {
+			f.PatchLabel = fmt.Sprintf("%.1f%%", f.PatchPercent)
+		}
+		files = append(files, f)
 	}
 
 	total := totalTally(p)
 	data := htmlData{
-		Module:  module,
-		Commit:  commit,
-		Percent: total.percent(),
-		Files:   files,
+		Module:       opts.Module,
+		Commit:       opts.Commit,
+		Percent:      total.percent(),
+		Diff:         opts.HaveDiff,
+		BodyClass:    "mode-all",
+		RangeLabel:   rangeLabel(opts),
+		PatchLabel:   "n/a",
+		ChangedFiles: changed,
+		Files:        files,
+	}
+	if opts.HaveDiff && changed > 0 {
+		data.BodyClass = "mode-diff"
+	}
+	var patch tally
+	for _, f := range files {
+		patch.covered += f.PatchCovered
+		patch.total += f.PatchTotal
+	}
+	if patch.total > 0 {
+		data.PatchLabel = fmt.Sprintf("%.1f%% (%d/%d statements)",
+			patch.percent(), patch.covered, patch.total)
 	}
 	return htmlTemplate.Execute(w, data)
 }
 
+// rangeLabel describes what the diff was taken against, for the header.
+func rangeLabel(opts htmlOptions) string {
+	switch {
+	case opts.DiffBase != "":
+		head := opts.DiffHead
+		if head == "" {
+			head = "working tree"
+		}
+		return opts.DiffBase + " … " + head
+	case opts.DiffFile != "":
+		return opts.DiffFile
+	}
+	return ""
+}
+
 type htmlData struct {
-	Module  string
-	Commit  string
-	Percent float64
-	Files   []htmlFile
+	Module       string
+	Commit       string
+	Percent      float64
+	Diff         bool
+	BodyClass    string
+	RangeLabel   string
+	PatchLabel   string
+	ChangedFiles int
+	Files        []htmlFile
 }
 
 type htmlFile struct {
-	Path    string
-	ID      string
-	Percent float64
-	Lines   []htmlLine
+	Path         string
+	ID           string
+	Percent      float64
+	Lines        []htmlLine
+	Changed      bool
+	PatchPercent float64
+	PatchCovered int
+	PatchTotal   int
+	PatchLabel   string
 }
 
+// htmlLine is one rendered row. Coverage, addedness and diff-view visibility
+// are kept separate so the template composes the CSS classes and the tests can
+// assert each property on its own. A row with Gap > 0 is an elision separator
+// rather than a source line.
 type htmlLine struct {
-	Num   int
-	Class string // "", "cov", or "uncov"
-	Text  string
+	Num     int
+	Class   string // "", "cov", or "uncov"
+	Text    string
+	Added   bool
+	Visible bool
+	Gap     int
 }
 
-// annotateFile classifies each source line: uncovered wins over covered
-// when a line spans blocks of both kinds, so red always flags lines that
-// still need a test.
-func annotateFile(rel, src string, blocks []block) htmlFile {
+// region is an inclusive run of source lines.
+type region struct{ start, end int }
+
+// diffRegions returns the line runs visible in the diff view: every added line
+// grown by context lines on each side, clamped to [1,totalLines] and merged
+// when the expanded runs touch or overlap. added must be sorted and deduped.
+func diffRegions(added []int, totalLines, context int) []region {
+	if totalLines <= 0 || len(added) == 0 {
+		return nil
+	}
+	if context < 0 {
+		context = 0
+	}
+	var out []region
+	for _, l := range added {
+		if l < 1 || l > totalLines {
+			continue // profile/source skew, or a line past EOF
+		}
+		s, e := l-context, l+context
+		if s < 1 {
+			s = 1
+		}
+		if e > totalLines {
+			e = totalLines
+		}
+		// Merge on touching, not just overlapping, so no "0 lines" separator
+		// is ever emitted between adjacent windows.
+		if n := len(out); n > 0 && s <= out[n-1].end+1 {
+			if e > out[n-1].end {
+				out[n-1].end = e
+			}
+			continue
+		}
+		out = append(out, region{s, e})
+	}
+	return out
+}
+
+// annotateFile classifies each source line and, when added is non-empty, marks
+// the diff-view context windows and inserts elision separators between them.
+// Uncovered wins over covered when a line spans blocks of both kinds, so red
+// always flags lines that still need a test.
+func annotateFile(rel, src string, blocks []block, added []int, context int) htmlFile {
 	srcLines := strings.Split(src, "\n")
-	classes := make([]string, len(srcLines)+1)
+	total := len(srcLines)
+
+	classes := make([]string, total+1)
 	var t tally
 	for _, b := range blocks {
 		t.add(b)
@@ -95,9 +232,46 @@ func annotateFile(rel, src string, blocks []block) htmlFile {
 		Path:    rel,
 		ID:      strings.NewReplacer("/", "-", ".", "-").Replace(rel),
 		Percent: t.percent(),
+		Changed: len(added) > 0,
 	}
+
+	addedSet := map[int]bool{}
+	visible := make([]bool, total+1)
+	if !f.Changed {
+		for i := range visible {
+			visible[i] = true
+		}
+	} else {
+		for _, l := range added {
+			addedSet[l] = true
+		}
+		for _, r := range diffRegions(added, total, context) {
+			for l := r.start; l <= r.end; l++ {
+				visible[l] = true
+			}
+		}
+	}
+
+	// Hidden lines stay in the slice — they are what the all-files view
+	// renders — and only the separator rows are new.
+	hidden := 0
 	for i, text := range srcLines {
-		f.Lines = append(f.Lines, htmlLine{Num: i + 1, Class: classes[i+1], Text: text})
+		n := i + 1
+		if !visible[n] {
+			hidden++
+			f.Lines = append(f.Lines, htmlLine{Num: n, Class: classes[n], Text: text})
+			continue
+		}
+		if hidden > 0 {
+			f.Lines = append(f.Lines, htmlLine{Gap: hidden})
+			hidden = 0
+		}
+		f.Lines = append(f.Lines, htmlLine{
+			Num: n, Class: classes[n], Text: text, Added: addedSet[n], Visible: true,
+		})
+	}
+	if hidden > 0 {
+		f.Lines = append(f.Lines, htmlLine{Gap: hidden})
 	}
 	return f
 }
@@ -114,6 +288,7 @@ var htmlTemplate = template.Must(template.New("report").Parse(`<!DOCTYPE html>
   --panel: #f6f8fa; --border: #d0d7de; --accent: #0969da;
   --cov-bg: #e6f4ea; --cov-edge: #1a7f37;
   --uncov-bg: #ffebe9; --uncov-edge: #cf222e;
+  --add-bg: #eef4ff; --add-edge: #0969da; --gap-fg: #656d76;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -121,6 +296,7 @@ var htmlTemplate = template.Must(template.New("report").Parse(`<!DOCTYPE html>
     --panel: #161b22; --border: #30363d; --accent: #4493f8;
     --cov-bg: #12261e; --cov-edge: #2ea043;
     --uncov-bg: #2d1517; --uncov-edge: #f85149;
+    --add-bg: #10203a; --add-edge: #4493f8; --gap-fg: #8d96a0;
   }
 }
 * { box-sizing: border-box; }
@@ -137,10 +313,20 @@ header {
 header h1 { font-size: 15px; margin: 0; }
 header .total { color: var(--accent); font-weight: 600; }
 header .meta { color: var(--muted); font-size: 12px; }
+.modes { display: flex; gap: 6px; }
+.modes button {
+  font: inherit; font-size: 12px; padding: 2px 10px; cursor: pointer;
+  background: var(--bg); color: var(--fg);
+  border: 1px solid var(--border); border-radius: 4px;
+}
+.modes button.active {
+  background: var(--accent); color: #fff; border-color: var(--accent);
+}
 .legend { margin-left: auto; font-size: 12px; color: var(--muted); }
 .legend .cov, .legend .uncov { padding: 1px 8px; border-radius: 3px; }
 .legend .cov { background: var(--cov-bg); }
 .legend .uncov { background: var(--uncov-bg); }
+.legend .plus { color: var(--add-edge); font-weight: 600; }
 main { display: flex; flex: 1; min-height: 0; }
 nav {
   width: 320px; overflow-y: auto; border-right: 1px solid var(--border);
@@ -171,34 +357,75 @@ pre .n {
   display: inline-block; width: 4.5em; text-align: right;
   padding-right: 12px; color: var(--muted); user-select: none;
 }
+pre .g {
+  display: inline-block; width: 1.3em; text-align: center;
+  color: var(--add-edge); user-select: none;
+}
 /* Tabs are measured from the start of the line box, so the code must live
    in its own inline-block for indentation to survive the number prefix. */
 pre .t { display: inline-block; white-space: pre; vertical-align: top; }
 pre .cov { background: var(--cov-bg); box-shadow: inset 3px 0 var(--cov-edge); }
 pre .uncov { background: var(--uncov-bg); box-shadow: inset 3px 0 var(--uncov-edge); }
+pre .gap {
+  color: var(--gap-fg); background: var(--panel); font-size: 11px;
+  padding: 2px 0 2px 16px; margin: 4px 0;
+  border-top: 1px solid var(--border); border-bottom: 1px solid var(--border);
+}
+/* Two stacked inset bars: the first shadow paints on top, so 0-3px marks the
+   line as added and 3-6px keeps its coverage colour. Spelled out per
+   combination because .add already outranks the bare .cov/.uncov rules. */
+body.mode-diff pre .add .g::before { content: "+"; font-weight: 600; }
+body.mode-diff pre .add {
+  background: var(--add-bg); box-shadow: inset 3px 0 var(--add-edge);
+}
+body.mode-diff pre .add.cov {
+  background: var(--cov-bg);
+  box-shadow: inset 3px 0 var(--add-edge), inset 6px 0 var(--cov-edge);
+}
+body.mode-diff pre .add.uncov {
+  background: var(--uncov-bg);
+  box-shadow: inset 3px 0 var(--add-edge), inset 6px 0 var(--uncov-edge);
+}
+/* Context lines keep their coverage colours; only the gutter dims, so the
+   surrounding code stays fully legible. */
+body.mode-diff pre span:not(.add) > .n { opacity: .55; }
+body.mode-diff pre .off { display: none; }
+body.mode-all pre .gap { display: none; }
+body.mode-all .diff-only { display: none; }
+body.mode-diff .all-only { display: none; }
+body.mode-diff nav a:not(.changed) { display: none; }
+body.mode-diff section:not(.changed) { display: none !important; }
+.empty { color: var(--muted); padding: 24px; }
 </style>
 </head>
-<body>
+<body class="{{.BodyClass}}">
 <header>
   <h1>{{.Module}}</h1>
   <span class="total">{{printf "%.1f" .Percent}}%</span>
   {{if .Commit}}<span class="meta">commit {{.Commit}}</span>{{end}}
+  {{if .Diff}}<span class="meta diff-only">patch {{.PatchLabel}} · {{.RangeLabel}}</span>
+  <span class="modes">
+    <button type="button" data-mode="diff">Changed only</button>
+    <button type="button" data-mode="all">All files</button>
+  </span>{{end}}
   <span class="legend">
     <span class="cov">covered</span> <span class="uncov">not covered</span>
-    plain: not tracked
+    plain: not tracked{{if .Diff}}
+    <span class="diff-only"><span class="plus">+</span> added</span>{{end}}
   </span>
 </header>
 <main>
 <nav>
-{{range .Files}}<a href="#{{.ID}}" data-target="{{.ID}}">
-  <span>{{.Path}}</span><span class="pct">{{printf "%.1f" .Percent}}%</span>
+{{range .Files}}<a href="#{{.ID}}" data-target="{{.ID}}"{{if .Changed}} class="changed"{{end}}>
+  <span>{{.Path}}</span><span class="pct all-only">{{printf "%.1f" .Percent}}%</span>
+  <span class="pct diff-only">{{.PatchLabel}}</span>
 </a>
 {{end}}</nav>
-{{range .Files}}<section id="{{.ID}}">
-<h2>{{.Path}} — {{printf "%.1f" .Percent}}%</h2>
-<pre>{{range .Lines}}<span{{if .Class}} class="{{.Class}}"{{end}}><span class="n">{{.Num}}</span><span class="t">{{.Text}}</span></span>{{end}}</pre>
+{{range .Files}}<section id="{{.ID}}"{{if .Changed}} class="changed"{{end}}>
+<h2>{{.Path}} — <span class="all-only">{{printf "%.1f" .Percent}}%</span><span class="diff-only">patch {{.PatchLabel}}</span></h2>
+<pre>{{range .Lines}}{{if .Gap}}<span class="gap">&hellip; {{.Gap}} unchanged lines &hellip;</span>{{else}}<span class="{{.Class}}{{if .Added}} add{{end}}{{if not .Visible}} off{{end}}"><span class="n">{{.Num}}</span><span class="g"></span><span class="t">{{.Text}}</span></span>{{end}}{{end}}</pre>
 </section>
-{{end}}</main>
+{{end}}{{if .Diff}}<p class="empty diff-only"{{if .ChangedFiles}} hidden{{end}}>No coverable changes in {{.RangeLabel}}.</p>{{end}}</main>
 <script>
 const links = document.querySelectorAll('nav a');
 const show = id => {
@@ -210,6 +437,23 @@ const show = id => {
 links.forEach(a => a.addEventListener('click', () => show(a.dataset.target)));
 const initial = location.hash.slice(1);
 show(document.getElementById(initial) ? initial : (links[0] && links[0].dataset.target));
+const setMode = m => {
+  document.body.classList.toggle('mode-diff', m === 'diff');
+  document.body.classList.toggle('mode-all', m !== 'diff');
+  document.querySelectorAll('.modes button').forEach(b =>
+    b.classList.toggle('active', b.dataset.mode === m));
+  // The deep-linked or previously selected file may not exist in the new
+  // mode; fall back to the first one that does.
+  const sel = m === 'diff' ? 'nav a.changed' : 'nav a';
+  const active = document.querySelector('nav a.active');
+  if (!active || !active.matches(sel)) {
+    const first = document.querySelector(sel);
+    if (first) show(first.dataset.target);
+  }
+};
+document.querySelectorAll('.modes button').forEach(b =>
+  b.addEventListener('click', () => setMode(b.dataset.mode)));
+setMode(document.body.classList.contains('mode-diff') ? 'diff' : 'all');
 </script>
 </body>
 </html>

--- a/tools/covreport/html.go
+++ b/tools/covreport/html.go
@@ -68,7 +68,9 @@ func renderHTML(out io.Writer, coverage profile, options htmlOptions) error {
 			fmt.Fprintf(os.Stderr, "covreport: skipping %s: %v\n", relPath, err)
 			continue
 		}
-		addedLines := options.Added[relPath]
+		// Copied because sort.Ints and dedupInts both write through the slice,
+		// and options.Added belongs to the caller.
+		addedLines := append([]int(nil), options.Added[relPath]...)
 		sort.Ints(addedLines)
 		addedLines = dedupInts(addedLines)
 
@@ -76,11 +78,22 @@ func renderHTML(out io.Writer, coverage profile, options htmlOptions) error {
 			addedLines, options.Context)
 		if file.Changed {
 			changedCount++
-			// Patch numbers come from the profile, not the annotated source,
-			// so the header always matches the markdown report.
+			// Patch numbers come from the profile, not the annotated source, so
+			// they match the markdown report.
 			patchTally := tallies[relPath]
 			file.PatchCovered, file.PatchTotal = patchTally.covered, patchTally.total
 			file.PatchPercent = patchTally.percent()
+
+			// Every added line fell outside the source read for this file —
+			// profile/source skew, or a -diff-head the profile was not built
+			// from. The diff view would show the file as one elision row with
+			// no hint that the two disagree, so say so.
+			if !hasVisibleRow(file) {
+				fmt.Fprintf(os.Stderr,
+					"covreport: %s: no changed line is within the source read "+
+						"for it (%d lines); diff and source disagree\n",
+					relPath, countSourceRows(file))
+			}
 		}
 		file.PatchLabel = "n/a"
 		if file.PatchTotal > 0 {
@@ -104,16 +117,42 @@ func renderHTML(out io.Writer, coverage profile, options htmlOptions) error {
 	if options.HaveDiff && changedCount > 0 {
 		data.BodyClass = "mode-diff"
 	}
+	// Summed from the tallies rather than from files, so a file whose source
+	// could not be read still counts: it is dropped from the rendered listing
+	// above, but its statements belong in the header either way, and leaving
+	// them out inflates the percentage against the markdown report.
 	var patchTotal tally
-	for _, file := range files {
-		patchTotal.covered += file.PatchCovered
-		patchTotal.total += file.PatchTotal
+	for relPath := range options.Added {
+		patchTotal.covered += tallies[relPath].covered
+		patchTotal.total += tallies[relPath].total
 	}
 	if patchTotal.total > 0 {
 		data.PatchLabel = fmt.Sprintf("%.1f%% (%d/%d statements)",
 			patchTotal.percent(), patchTotal.covered, patchTotal.total)
 	}
 	return htmlTemplate.Execute(out, data)
+}
+
+// hasVisibleRow reports whether any source row of the file shows in the diff
+// view. A changed file with none means no added line landed inside its source.
+func hasVisibleRow(file htmlFile) bool {
+	for _, row := range file.Lines {
+		if row.Visible {
+			return true
+		}
+	}
+	return false
+}
+
+// countSourceRows counts the file's source lines, excluding elision separators.
+func countSourceRows(file htmlFile) int {
+	count := 0
+	for _, row := range file.Lines {
+		if row.Gap == 0 {
+			count++
+		}
+	}
+	return count
 }
 
 // rangeLabel describes what the diff was taken against, for the header.
@@ -430,6 +469,8 @@ body.mode-diff section:not(.changed) { display: none !important; }
 {{end}}</nav>
 {{range .Files}}<section id="{{.ID}}"{{if .Changed}} class="changed"{{end}}>
 <h2>{{.Path}} — <span class="all-only">{{printf "%.1f" .Percent}}%</span><span class="diff-only">patch {{.PatchLabel}}</span></h2>
+{{/* The row loop below stays on one line: it is inside <pre>, so any newline
+     added for readability would render as a blank line in the source view. */ -}}
 <pre>{{range .Lines}}{{if .Gap}}<span class="gap">&hellip; {{.Gap}} unchanged lines &hellip;</span>{{else}}<span class="{{.Class}}{{if .Added}} add{{end}}{{if not .Visible}} off{{end}}"><span class="n">{{.Num}}</span><span class="g"></span><span class="t">{{.Text}}</span></span>{{end}}{{end}}</pre>
 </section>
 {{end}}{{if .Diff}}<p class="empty diff-only"{{if .ChangedFiles}} hidden{{end}}>No coverable changes in {{.RangeLabel}}.</p>{{end}}</main>

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -117,20 +117,23 @@ func main() {
 
 // loadAddedLines resolves the added-line map from either a pre-generated diff
 // file (-diff) or a revision range (-diff-base/-diff-head). The bool reports
-// whether a diff was requested at all.
+// whether a diff was requested at all, so it is true whenever one of those
+// flags was given — including when reading or parsing it then failed. A caller
+// that chooses to carry on past the error therefore still knows a patch column
+// was asked for, rather than silently rendering the report without one.
 func loadAddedLines(diffPath, diffBase, diffHead string) (map[string][]int, bool, error) {
 	switch {
 	case diffPath != "":
 		added, err := parseDiff(diffPath)
-		return added, err == nil, err
+		return added, true, err
 	case diffBase != "":
 		diffText, err := gitDiff(diffBase, diffHead)
 		if err != nil {
-			return nil, false, err
+			return nil, true, err
 		}
 		source := fmt.Sprintf("git diff %s %s", diffBase, diffHead)
 		added, err := parseDiffBytes(diffText, source)
-		return added, err == nil, err
+		return added, true, err
 	}
 	return nil, false, nil
 }

--- a/tools/covreport/main.go
+++ b/tools/covreport/main.go
@@ -38,6 +38,12 @@ func main() {
 	baseName := flag.String("base-name", "main", "display name of the base branch")
 	format := flag.String("format", "markdown",
 		"output format: markdown (PR report) or html (annotated source browser)")
+	diffBase := flag.String("diff-base", "",
+		"base revision; runs `git diff -U0 <base> [<head>]` for patch coverage")
+	diffHead := flag.String("diff-head", "",
+		"head revision for -diff-base (default: working tree); sources read via git show")
+	diffContext := flag.Int("diff-context", 3,
+		"context lines shown around changed lines in the html diff view")
 	flag.Parse()
 
 	if *coverPath == "" {
@@ -53,14 +59,40 @@ func main() {
 		*module = m
 	}
 
+	if *diffPath != "" && *diffBase != "" {
+		fmt.Fprintln(os.Stderr, "covreport: cannot use -diff with -diff-base")
+		os.Exit(2)
+	}
+	if *diffHead != "" && *diffBase == "" {
+		fmt.Fprintln(os.Stderr, "covreport: -diff-head requires -diff-base")
+		os.Exit(2)
+	}
+
 	head, err := parseProfile(*coverPath, *module)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
 		os.Exit(1)
 	}
 
+	added, haveDiff, err := loadAddedLines(*diffPath, *diffBase, *diffHead)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
+		os.Exit(1)
+	}
+
 	if *format == "html" {
-		if err := renderHTML(os.Stdout, head, *module, *commit, nil); err != nil {
+		opts := htmlOptions{
+			Module:   *module,
+			Commit:   *commit,
+			Added:    added,
+			HaveDiff: haveDiff,
+			DiffBase: *diffBase,
+			DiffHead: *diffHead,
+			DiffFile: *diffPath,
+			Context:  *diffContext,
+			Source:   sourceFor(*diffHead),
+		}
+		if err := renderHTML(os.Stdout, head, opts); err != nil {
 			fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
 			os.Exit(1)
 		}
@@ -80,18 +112,36 @@ func main() {
 		}
 	}
 
-	var added map[string][]int
-	haveDiff := false
-	if *diffPath != "" {
-		added, err = parseDiff(*diffPath)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "covreport: %v\n", err)
-			os.Exit(1)
-		}
-		haveDiff = true
-	}
-
 	fmt.Print(renderMarkdown(head, base, added, haveDiff, *module, *commit, *baseName))
+}
+
+// loadAddedLines resolves the added-line map from either a pre-generated diff
+// file (-diff) or a revision range (-diff-base/-diff-head). The bool reports
+// whether a diff was requested at all.
+func loadAddedLines(diffPath, diffBase, diffHead string) (map[string][]int, bool, error) {
+	switch {
+	case diffPath != "":
+		added, err := parseDiff(diffPath)
+		return added, err == nil, err
+	case diffBase != "":
+		out, err := gitDiff(diffBase, diffHead)
+		if err != nil {
+			return nil, false, err
+		}
+		source := fmt.Sprintf("git diff %s %s", diffBase, diffHead)
+		added, err := parseDiffBytes(out, source)
+		return added, err == nil, err
+	}
+	return nil, false, nil
+}
+
+// sourceFor picks where head sources are read from: the working directory when
+// no head revision was named, otherwise that revision.
+func sourceFor(rev string) sourceReader {
+	if rev == "" {
+		return func(rel string) ([]byte, error) { return os.ReadFile(rel) }
+	}
+	return func(rel string) ([]byte, error) { return gitShow(rev, rel) }
 }
 
 func moduleFromGoMod(path string) (string, error) {
@@ -158,8 +208,8 @@ func parseDiff(path string) (map[string][]int, error) {
 	return parseDiffBytes(data, path)
 }
 
-// parseDiffBytes is parseDiff over an in-memory diff; source only names the
-// input in error messages.
+// parseDiffBytes extracts added-line numbers per new-side path. source names
+// where the diff came from, for error messages.
 func parseDiffBytes(data []byte, source string) (map[string][]int, error) {
 	added := map[string][]int{}
 	current := ""
@@ -284,41 +334,56 @@ func patchCoverage(head profile, added map[string][]int, module string) []fileSt
 	sort.Strings(files)
 
 	for _, file := range files {
-		lines := added[file]
-		lineSet := map[int]bool{}
-		for _, l := range lines {
-			lineSet[l] = true
-		}
-		blocks := head[module+"/"+file]
-		var st fileStat
-		st.file = file
-		for _, b := range blocks {
-			touched := false
-			for l := b.startLine; l <= b.endLine; l++ {
-				if lineSet[l] {
-					touched = true
-					break
-				}
-			}
-			if !touched {
-				continue
-			}
-			st.t.add(b)
-			if b.count == 0 {
-				for l := b.startLine; l <= b.endLine; l++ {
-					if lineSet[l] {
-						st.uncovered = append(st.uncovered, l)
-					}
-				}
-			}
-		}
+		st := fileStatFor(file, added[file], head[module+"/"+file])
 		if st.t.total > 0 {
-			sort.Ints(st.uncovered)
-			st.uncovered = dedupInts(st.uncovered)
 			stats = append(stats, st)
 		}
 	}
 	return stats
+}
+
+// fileStatFor computes one file's patch tally: the statements of every block
+// overlapping an added line, plus the added lines that fall in uncovered
+// blocks.
+func fileStatFor(file string, added []int, blocks []block) fileStat {
+	lineSet := map[int]bool{}
+	for _, l := range added {
+		lineSet[l] = true
+	}
+	st := fileStat{file: file}
+	for _, b := range blocks {
+		touched := false
+		for l := b.startLine; l <= b.endLine; l++ {
+			if lineSet[l] {
+				touched = true
+				break
+			}
+		}
+		if !touched {
+			continue
+		}
+		st.t.add(b)
+		if b.count == 0 {
+			for l := b.startLine; l <= b.endLine; l++ {
+				if lineSet[l] {
+					st.uncovered = append(st.uncovered, l)
+				}
+			}
+		}
+	}
+	sort.Ints(st.uncovered)
+	st.uncovered = dedupInts(st.uncovered)
+	return st
+}
+
+// patchTallies returns the patch tally of every changed file, including files
+// with no coverable statements, which the html sidebar still needs to list.
+func patchTallies(head profile, added map[string][]int, module string) map[string]tally {
+	out := make(map[string]tally, len(added))
+	for file, lines := range added {
+		out[file] = fileStatFor(file, lines, head[module+"/"+file]).t
+	}
+	return out
 }
 
 func dedupInts(s []int) []int {
@@ -418,7 +483,8 @@ func renderMarkdown(head, base profile, added map[string][]int, haveDiff bool,
 
 	b.WriteString("---\n")
 	b.WriteString("To browse the full HTML report locally, check out this branch and run " +
-		"`make test-coverage`, then open `coverage.html`.\n")
+		"`make test-coverage`, then open `coverage.html`. For a view of just these " +
+		"changed lines, run `make coverage-diff BASE=" + baseName + "`.\n")
 	return b.String()
 }
 


### PR DESCRIPTION
**Stack 4/5** — base: #86. Review only the top commit; the rest belongs to the PRs below.

## Summary

Adds `-format html -diff-base <rev> [-diff-head <rev>]`, so the HTML report can focus on just the lines a change touches.

- `covreport` runs `git diff -U0` itself and renders only the changed hunks plus three lines of context, eliding untouched regions with a "… N unchanged lines …" separator.
- Added lines get a `+` gutter and a blue edge bar stacked outside their coverage colour, so "added" and "covered" read as two independent signals.
- The page holds **both** views and switches by toggling a class on `<body>` — "Changed only" (sidebar shows just the changed files with their patch coverage) and "All files" — with the source text emitted only once.
- When the diff is empty the page opens in all-files mode with an empty-state message.
- New make target: `make coverage-diff BASE=<rev>` (default `main`). It deliberately does not depend on `test-coverage`, which would overwrite `coverage.html` with the full view.
- `-diff <file>` (a pre-generated diff) still works and is mutually exclusive with `-diff-base`; `-diff-head` without `-diff-base` is an error.

Along the way `renderHTML` gains an `htmlOptions` struct rather than growing more positional parameters, and the diff/patch helpers are split into pure functions (`diffRegions`, `parseDiffBytes`, `annotateFile`, `patchTallies`) so they can be tested without git or a filesystem.

## Test plan

- [x] `diffRegions` — clamping to the file bounds, and merging windows that touch as well as overlap, so no "0 unchanged lines" separator can be emitted
- [x] `annotateFile` — which rows are visible, where separators land, and that hidden rows stay in the slice for the all-files view
- [x] `patchTallies` / `patchCoverage` — patch numbers come from the profile so the HTML header always matches the markdown report
- [x] `renderHTML` in all three shapes: with a diff, without one, and with an empty diff
- [x] **Parity check**: `-diff <file>` and `-diff-base`/`-diff-head` produce byte-identical markdown, so CI is unaffected
- [x] Rendered a real 9-file/183-statement diff and verified light/dark themes, the elision separators, the `+` markers, and the "All files" toggle in headless Chromium (driven by a real click, not a CSS-only check)
- [x] Error paths: bad revision exits 1 with git's own message; `-diff` with `-diff-base` and `-diff-head` without `-diff-base` exit 2
- [x] `make build`, `go vet ./...`, `golangci-lint run` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUFqqeXLnkNLZYqy7FJ8gv)_